### PR TITLE
fix logic for recordedCommandMaps when swithing from Insert Mode

### DIFF
--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -78,7 +78,7 @@ export class Dispatcher {
         commands.executeCommand('setContext', 'amVim.mode', this.currentMode.name);
 
         // For use in repeat command
-        if(previousMode && previousMode.id == ModeID.INSERT) {
+        if (previousMode && previousMode.id == ModeID.INSERT) {
             const recordedCommandMaps = (previousMode as ModeInsert).recordedCommandMaps;
             this.currentMode.onDidRecordFinish(recordedCommandMaps);
         }

--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -70,19 +70,17 @@ export class Dispatcher {
             this.currentMode.exit();
         }
 
+        const previousMode = this.currentMode;
+
         this.currentMode = this.modes[id];
         this.currentMode.enter();
 
         commands.executeCommand('setContext', 'amVim.mode', this.currentMode.name);
 
-        // For use in repeat command.
-        if (id === ModeID.INSERT) {
-            (this.modes[ModeID.INSERT] as ModeInsert).startRecord();
-        }
-        else {
-            const insertMode = this.modes[ModeID.INSERT] as ModeInsert;
-            insertMode.stopRecord();
-            this.currentMode.onDidRecordFinish(insertMode.recordedCommandMaps);
+        // For use in repeat command
+        if(previousMode && previousMode.id == ModeID.INSERT) {
+            const recordedCommandMaps = (previousMode as ModeInsert).recordedCommandMaps;
+            this.currentMode.onDidRecordFinish(recordedCommandMaps);
         }
     }
 

--- a/src/Modes/Insert.ts
+++ b/src/Modes/Insert.ts
@@ -87,12 +87,12 @@ export class ModeInsert extends Mode {
     private _recordedCommandMaps: CommandMap[];
     get recordedCommandMaps() { return this._recordedCommandMaps; }
 
-    startRecord(): void {
+    private startRecord(): void {
         this.shouldRecord = true;
         this._recordedCommandMaps = [];
     }
 
-    stopRecord(): void {
+    private stopRecord(): void {
         this.shouldRecord = false;
     }
 

--- a/src/Modes/Insert.ts
+++ b/src/Modes/Insert.ts
@@ -41,12 +41,12 @@ export class ModeInsert extends Mode {
         });
     }
 
-    enter() {
+    enter() : void {
       super.enter();
       this.startRecord();
     }
 
-    exit() {
+    exit() : void {
         super.exit();
         this.stopRecord();
     }

--- a/src/Modes/Insert.ts
+++ b/src/Modes/Insert.ts
@@ -41,6 +41,16 @@ export class ModeInsert extends Mode {
         });
     }
 
+    enter() {
+      super.enter();
+      this.startRecord();
+    }
+
+    exit() {
+        super.exit();
+        this.stopRecord();
+    }
+
     input(key: string, args: {replaceCharCnt?: number} = {}): MatchResultKind {
         const matchResultKind = super.input(key);
 


### PR DESCRIPTION
`recordedCommandMaps` should only apply when we switch from insert mode.

for example try this key sequence starting in `Normal` Mode

`i12345<esc>V<esc>.`

you will see that `12345` is printed multiple times. this pr fixes this issue.