### PR TITLE
workaround for yanking last line

### DIFF
--- a/src/Actions/Register.ts
+++ b/src/Actions/Register.ts
@@ -23,7 +23,19 @@ export class ActionRegister {
         }
 
         ActionRegister.stash = ranges.map(range => {
-            return activeTextEditor.document.getText(range);
+            const document = activeTextEditor.document;
+            const areLines = range.start.character == 0 && range.end.character == 0;
+            if (!areLines) {
+                return document.getText(range);
+            }
+            /* document.getText is broken, it doesn't return last line.
+             * TODO: remove this workaround for yanking last line. */
+            let lines = [];
+            for (var lineNo = range.start.line; lineNo < range.end.line; ++lineNo){
+                lines.push(document.lineAt(lineNo).text);
+            }
+            let text = lines.join('\n');
+            return text ? text + '\n' : text;
         }).join('');
 
         return Promise.resolve(true);


### PR DESCRIPTION
`document.getText(range)` is broken. it does not return the last line in the range.
This a workaround to use `document.lineAt(line_number)` instead which returns the correct values.