### PR TITLE
Bug in `GenericMapper.match` when there are multiple input commands at once

### DIFF
--- a/src/Mappers/Generic.ts
+++ b/src/Mappers/Generic.ts
@@ -110,7 +110,10 @@ export abstract class GenericMapper {
             return {kind: MatchResultKind.FAILED};
         }
         else if (GenericMapper.isMapLeaf(node)) {
-            const map = node as GenericMap;
+            // make a copy of the node object
+            const map = Object.assign({}, node) as GenericMap;
+            // always reinitialize args object
+            map.args = {};
 
             Object.getOwnPropertyNames(additionalArgs).forEach(name => {
                 map.args = map.args || {};

--- a/src/Modes/Mode.ts
+++ b/src/Modes/Mode.ts
@@ -59,6 +59,8 @@ export abstract class Mode {
             inputs = this.inputs;
         }
 
+        // FIXME: without the bugfix (copy of args.motion) all map objects will be the same object...
+        // that means that existing map objects in `this.mapper` will "transform" into the newest map object
         const {kind, map} = this.mapper.match(inputs);
 
         if (kind === MatchResultKind.FAILED) {

--- a/test/MotionIntegration.test.ts
+++ b/test/MotionIntegration.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+import * as TestUtil from './Util';
+import {Position} from 'vscode';
+
+import {Configuration} from '../src/Configuration';
+import {ModeNormal} from '../src/Modes/Normal';
+
+export function run() {
+
+    Configuration.init();
+
+    test('Fast motion test', (done) => {
+        TestUtil.setText('hello world').then(() => {
+            TestUtil.setCursorScreenPosition(new Position(0, 3));
+            // hello world
+            //    ^
+            let normalMode = new ModeNormal();
+            normalMode.input('w');
+            normalMode.input('b');
+            normalMode.input('l');
+            // expected
+            // hello world
+            //  ^
+            setTimeout(() => {
+                // without the "bugfix" the cursor position will be wrong
+                assert.deepEqual(new Position(0, 1), TestUtil.getCursorScreenPosition());
+                done();
+            }, 100);
+        });
+    });
+}

--- a/test/Util.ts
+++ b/test/Util.ts
@@ -1,4 +1,4 @@
-import {workspace, window, Uri, Position} from 'vscode';
+import {workspace, window, Uri, Position, Range, Selection} from 'vscode';
 
 export function createTempDocument(content?: string) {
 
@@ -16,4 +16,28 @@ export function createTempDocument(content?: string) {
             }
         });
 
+}
+
+export function setText(text: string) {
+    let editor = window.activeTextEditor;
+
+    return editor.edit(builder => {
+        const document = editor.document;
+        const lastLine = document.lineAt(document.lineCount - 1);
+
+        const start = new Position(0, 0);
+        const end = new Position(document.lineCount - 1, lastLine.text.length);
+
+        builder.replace(new Range(start, end), text);
+    });
+}
+
+export function setCursorScreenPosition(position: Position) {
+    const editor = window.activeTextEditor;
+    editor.selection = new Selection(position, position);
+}
+
+export function getCursorScreenPosition(): Position {
+    const editor = window.activeTextEditor;
+    return editor.selection.active;
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -4,8 +4,10 @@
 //
 
 import * as MotionWordTests from './MotionWord.test';
+import * as MotionIntegrationTest from './MotionIntegration.test';
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", () => {
-    MotionWordTests.run();
+    //MotionWordTests.run();
+    MotionIntegrationTest.run();
 });


### PR DESCRIPTION
This bug is hard to explain in words. So I created this pull-request to illustrate it with code.

I was playing around with some tests to understand the code better. I was "simulating" input in my tests. See the `MotionIntegrationTest`.

The test did not behave as expected. 
Then I did some debugging. The debugging showed that in `Mode` the `map` objects did seem to somehow get overwritten when multiple maps are in the `this.pendings` array.
When there where more than one map-object in `this.pendings` they were essentially the same map object (`this.pendings[0] === this.pendings[1]`)

The added code in Generic.ts fixes seems to fix this problem. Although I am not 100% sure why I have to do this.

So this pull-request is not a complete solution to the problem.
I hope I can help you find the bug and eliminate it!