### PR TITLE
Use TextEditorCursorStyle.Block for Normal mode.

### DIFF
--- a/src/Actions/BlockCursor.ts
+++ b/src/Actions/BlockCursor.ts
@@ -1,28 +1,15 @@
-import {window, Disposable, Selection, Range, TextEditor} from 'vscode';
+import {window, TextEditor, TextEditorCursorStyle} from 'vscode';
 
 export class ActionBlockCursor {
 
-    private static decoration = window.createTextEditorDecorationType({
-        borderStyle: 'solid',
-        borderWidth: '0 0 0 1ch',
-        borderColor: 'rgba(128, 128, 128, 0.7)',
-        borderRadius: '2px',
-    });
-
     private static isOn = false;
-    private static disposables: Disposable[] = [];
 
     static on(): Thenable<boolean> {
         ActionBlockCursor.isOn = true;
 
-        ActionBlockCursor.disposables.push(window.onDidChangeTextEditorSelection(e => {
-            ActionBlockCursor.handler(e.textEditor, e.selections);
-        }));
-
-        const activeTextEditor = window.activeTextEditor;
-        if (activeTextEditor) {
-            return ActionBlockCursor.handler(activeTextEditor, activeTextEditor.selections);
-        }
+        let opt = window.activeTextEditor.options;
+        opt.cursorStyle = TextEditorCursorStyle.Block;
+        window.activeTextEditor.options = opt;
 
         return Promise.resolve(true);
     }
@@ -30,28 +17,10 @@ export class ActionBlockCursor {
     static off(): Thenable<boolean> {
         ActionBlockCursor.isOn = false;
 
-        Disposable.from(...ActionBlockCursor.disposables).dispose();
-
-        const activeTextEditor = window.activeTextEditor;
-        if (activeTextEditor) {
-            activeTextEditor.setDecorations(ActionBlockCursor.decoration, []);
-        }
+        let opt = window.activeTextEditor.options;
+        opt.cursorStyle = TextEditorCursorStyle.Line;
+        window.activeTextEditor.options = opt;
 
         return Promise.resolve(true);
     }
-
-    private static handler(textEditor: TextEditor, selections: Selection[]): Thenable<boolean> {
-        if (! ActionBlockCursor.isOn) {
-            return Promise.resolve(false);
-        }
-
-        const ranges = selections.map(selection => {
-            return new Range(selection.active, selection.active.translate(0, +1));
-        });
-
-        textEditor.setDecorations(ActionBlockCursor.decoration, ranges);
-
-        return Promise.resolve(true);
-    }
-
 }


### PR DESCRIPTION
This uses Bock cursor style form vscode new api for Normal mode.

I tried to use the same for Vitual Mode, but vscode Ranges are not inclusive and if we use cursor block style the character that is behind the cursor is not selected.