### PR TITLE
Semi support for `=` filter

### DIFF
--- a/src/Actions/BlockCursor.ts
+++ b/src/Actions/BlockCursor.ts
@@ -9,9 +9,9 @@ export class ActionBlockCursor {
             return Promise.resolve(false);
         }
 
-        let opt = window.activeTextEditor.options;
+        let opt = activeTextEditor.options;
         opt.cursorStyle = TextEditorCursorStyle.Block;
-        window.activeTextEditor.options = opt;
+        activeTextEditor.options = opt;
 
         return Promise.resolve(true);
     }
@@ -23,9 +23,9 @@ export class ActionBlockCursor {
             return Promise.resolve(false);
         }
 
-        let opt = window.activeTextEditor.options;
+        let opt = activeTextEditor.options;
         opt.cursorStyle = TextEditorCursorStyle.Line;
-        window.activeTextEditor.options = opt;
+        activeTextEditor.options = opt;
 
         return Promise.resolve(true);
     }

--- a/src/Actions/Filter.ts
+++ b/src/Actions/Filter.ts
@@ -13,8 +13,8 @@ class Format {
             return Promise.resolve(false);
         }
 
-        if ((activeTextEditor.selections.length === 0)
-        || (activeTextEditor.selections.length === 1 && activeTextEditor.selection.isEmpty)
+        if (activeTextEditor.selections.length === 0
+        || activeTextEditor.selections.every((selection) => selection.isEmpty)
         ) {
             return Promise.resolve(false);
         }

--- a/src/Actions/Filter.ts
+++ b/src/Actions/Filter.ts
@@ -1,0 +1,54 @@
+import {commands, window} from 'vscode';
+import {Motion} from '../Motions/Motion';
+import {ActionMoveCursor} from './MoveCursor';
+import {ActionReveal} from './Reveal';
+
+class Format {
+
+    static bySelections(): Thenable<boolean> {
+        const activeTextEditor = window.activeTextEditor;
+
+        if (! activeTextEditor) {
+            return Promise.resolve(false);
+        }
+
+        if ((activeTextEditor.selections.length === 0)
+        || (activeTextEditor.selections.length === 1 && activeTextEditor.selection.isEmpty)
+        ) {
+            return Promise.resolve(false);
+        }
+
+        return commands.executeCommand('editor.action.format');
+    }
+
+    static byMotions(args: {
+        motions: Motion[]
+    }): Thenable<boolean> {
+        const activeTextEditor = window.activeTextEditor;
+
+        if (! activeTextEditor) {
+            return Promise.resolve(false);
+        }
+
+        const originalSelections = activeTextEditor.selections;
+
+        return ActionMoveCursor.byMotions({
+            motions: args.motions,
+            isVisualMode: true
+        })
+        .then(() => {
+            return commands.executeCommand('editor.action.format');
+        })
+        .then(() => {
+            activeTextEditor.selections = originalSelections;
+            return Promise.resolve(true);
+        })
+        .then(() => ActionReveal.primaryCursor());
+    }
+
+};
+
+
+export const ActionFilter = {
+    Format: Format
+};

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -18,6 +18,7 @@ import {ActionFind} from '../Actions/Find';
 import {ActionSelection} from '../Actions/Selection';
 import {ActionHistory} from '../Actions/History';
 import {ActionIndent} from '../Actions/Indent';
+import {ActionFilter} from '../Actions/Filter';
 import {ActionMode} from '../Actions/Mode';
 import {MotionCharacter} from '../Motions/Character';
 import {MotionLine} from '../Motions/Line';
@@ -153,6 +154,8 @@ export class ModeNormal extends Mode {
             ActionFind.byIndicator,
             ActionFind.prev,
         ] },
+
+        { keys: '= {motion}', actions: [ActionFilter.Format.byMotions] },
 
         { keys: 'u', actions: [
             ActionHistory.undo,

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -156,6 +156,7 @@ export class ModeNormal extends Mode {
         ] },
 
         { keys: '= {motion}', actions: [ActionFilter.Format.byMotions] },
+        { keys: '= =', actions: [ActionFilter.Format.byCursors] },
 
         { keys: 'u', actions: [
             ActionHistory.undo,

--- a/src/Modes/Visual.ts
+++ b/src/Modes/Visual.ts
@@ -11,6 +11,7 @@ import {ActionInsert} from '../Actions/Insert';
 import {ActionReplace} from '../Actions/Replace';
 import {ActionIndent} from '../Actions/Indent';
 import {ActionJoinLines} from '../Actions/JoinLines';
+import {ActionFilter} from '../Actions/Filter';
 import {ActionFind} from '../Actions/Find';
 import {ActionMode} from '../Actions/Mode';
 import {MotionLine} from '../Motions/Line';
@@ -70,6 +71,8 @@ export class ModeVisual extends Mode {
         ] },
 
         { keys: 'r {char}', actions: [ActionReplace.selections] },
+
+        { keys: '=', actions: [ActionFilter.Format.bySelections] },
 
         { keys: '<', actions: [ActionIndent.decrease] },
         { keys: '>', actions: [ActionIndent.increase] },

--- a/src/Modes/Visual.ts
+++ b/src/Modes/Visual.ts
@@ -22,7 +22,7 @@ export class ModeVisual extends Mode {
 
     private maps: CommandMap[] = [
         { keys: '{motion}', actions: [ActionMoveCursor.byMotions], args: {isVisualMode: true} },
-        { keys: '{textObject}', actions: [ActionSelection.expandByTextObject]}, 
+        { keys: '{textObject}', actions: [ActionSelection.expandByTextObject]},
 
         { keys: 'ctrl+b', actions: [ActionPage.up], args: {moveType: PageMoveType.Select} },
         { keys: 'ctrl+f', actions: [ActionPage.down], args: {moveType: PageMoveType.Select} },

--- a/src/Modes/VisualLine.ts
+++ b/src/Modes/VisualLine.ts
@@ -10,6 +10,7 @@ import {ActionDelete} from '../Actions/Delete';
 import {ActionInsert} from '../Actions/Insert';
 import {ActionReplace} from '../Actions/Replace';
 import {ActionJoinLines} from '../Actions/JoinLines';
+import {ActionFilter} from '../Actions/Filter';
 import {ActionFind} from '../Actions/Find';
 import {ActionMode} from '../Actions/Mode';
 import {ActionIndent} from '../Actions/Indent';
@@ -71,6 +72,8 @@ export class ModeVisualLine extends Mode {
         ] },
 
         { keys: 'r {char}', actions: [ActionReplace.selections] },
+
+        { keys: '=', actions: [ActionFilter.Format.bySelections] },
 
         { keys: '<', actions: [ActionIndent.decrease] },
         { keys: '>', actions: [ActionIndent.increase] },


### PR DESCRIPTION
Uses VSCode's built in formating command to format selections.
`{N} = =` is not supported yet.

Solves #126 .