### PR TITLE
fix #161, avoid wrong cursor style

### DIFF
--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -5,6 +5,7 @@ import {ModeNormal} from './Modes/Normal';
 import {ModeVisual} from './Modes/Visual';
 import {ModeVisualLine} from './Modes/VisualLine';
 import {ModeInsert} from './Modes/Insert';
+import {ActionBlockCursor} from './Actions/BlockCursor';
 import {ActionMode} from './Actions/Mode';
 import {ActionMoveCursor} from './Actions/MoveCursor';
 import {Configuration} from './Configuration';
@@ -58,6 +59,8 @@ export class Dispatcher {
             }),
             window.onDidChangeActiveTextEditor(() => {
                 if (Configuration.defaultModeID === ModeID.INSERT) {
+                    ActionBlockCursor.on();
+                    ActionBlockCursor.off();
                     ActionMode.toInsert();
                 }
                 else {


### PR DESCRIPTION
#161 As this is a [VSCode bug](https://github.com/Microsoft/vscode/issues/17513#issuecomment-268141409), we can simply force the cursor style change to Block then Line before change it to Insert mode. This could avoid the wrong cursor style. Already tested.

As the assign of the options skip new option if it is same as previous one, we have to do `ActionBlockCursor.on();ActionBlockCursor.off();` together.
