### PR TITLE
Implement {visual}u and {visual}U, tweak {visual}~

### DIFF
--- a/src/Modes/Visual.ts
+++ b/src/Modes/Visual.ts
@@ -1,4 +1,4 @@
-import {window} from 'vscode';
+import {commands, window} from 'vscode';
 import {StaticReflect} from '../LanguageExtensions/StaticReflect';
 import {SymbolMetadata} from '../Symbols/Metadata';
 import {RangeOffset} from '../Types/RangeOffset';
@@ -81,7 +81,19 @@ export class ModeVisual extends Mode {
             ActionReplace.selectionsWithCharacter,
             ActionSelection.shrinkToStarts,
         ] },
-        { keys: '~', actions: [ActionCase.switchSelections] },
+
+        { keys: '~', actions: [
+            ActionCase.switchSelections,
+            ActionSelection.shrinkToStarts,
+        ] },
+        { keys: 'u', actions: [
+            () => commands.executeCommand('editor.action.transformToLowercase'),
+            ActionSelection.shrinkToStarts,
+        ] },
+        { keys: 'U', actions: [
+            () => commands.executeCommand('editor.action.transformToUppercase'),
+            ActionSelection.shrinkToStarts,
+        ] },
 
         { keys: '=', actions: [ActionFilter.Format.bySelections] },
 

--- a/src/Modes/VisualLine.ts
+++ b/src/Modes/VisualLine.ts
@@ -1,4 +1,4 @@
-import {window} from 'vscode';
+import {commands, window} from 'vscode';
 import {StaticReflect} from '../LanguageExtensions/StaticReflect';
 import {SymbolMetadata} from '../Symbols/Metadata';
 import {RangeOffset} from '../Types/RangeOffset';
@@ -88,7 +88,19 @@ export class ModeVisualLine extends Mode {
             ActionReplace.selectionsWithCharacter,
             ActionSelection.shrinkToStarts,
         ] },
-        { keys: '~', actions: [ActionCase.switchSelections] },
+
+        { keys: '~', actions: [
+            ActionCase.switchSelections,
+            ActionSelection.shrinkToStarts,
+        ] },
+        { keys: 'u', actions: [
+            () => commands.executeCommand('editor.action.transformToLowercase'),
+            ActionSelection.shrinkToStarts,
+        ] },
+        { keys: 'U', actions: [
+            () => commands.executeCommand('editor.action.transformToUppercase'),
+            ActionSelection.shrinkToStarts,
+        ] },
 
         { keys: '=', actions: [ActionFilter.Format.bySelections] },
 


### PR DESCRIPTION
`{visual}u` and `{visual}U` are used for transforming selected text to lowercase and uppercase.

I tweaked `{visual}~` to behave similarly than in vim, i.e. that after the operation the selection is deselected. `{visual}u` and `{visual}U` behave that way as well.

(Side note: I noticed that `{visual}~` doesn't work with special characters, e.g. å, ä and ö.)