### PR TITLE
Support for N before commands

### DIFF
--- a/src/Actions/Register.ts
+++ b/src/Actions/Register.ts
@@ -150,15 +150,23 @@ export class ActionRegister {
         });
     }
 
-    static yankLines(): Thenable<boolean> {
+    static yankLines(args: {n?: number}): Thenable<boolean> {
+        args.n = args.n === undefined ? 1 : args.n;
+
         const activeTextEditor = window.activeTextEditor;
 
         if (! activeTextEditor) {
             return Promise.resolve(false);
         }
 
+        const ranges = args.n === 1
+            ? activeTextEditor.selections
+            : activeTextEditor.selections.map(selection => selection.with({
+                end: selection.end.translate(args.n! - 1),
+            }));
+
         return ActionRegister.yankRanges({
-            ranges: activeTextEditor.selections,
+            ranges: ranges,
             isLinewise: true,
         });
     }

--- a/src/Mappers/Generic.ts
+++ b/src/Mappers/Generic.ts
@@ -67,6 +67,8 @@ export abstract class GenericMapper {
         let matched = true;
         let additionalArgs = {};
 
+        let lastSpecialKeyMatch: SpecialKeyMatchResult | undefined;
+
         for (let index = 0; index < inputs.length; index++) {
             const input = inputs[index];
 
@@ -82,7 +84,7 @@ export abstract class GenericMapper {
                     return false;
                 }
 
-                match = specialKey.matchSpecial(inputs.slice(index), additionalArgs);
+                match = specialKey.matchSpecial(inputs.slice(index), additionalArgs, lastSpecialKeyMatch);
 
                 return match ? true : false;
             });
@@ -91,6 +93,7 @@ export abstract class GenericMapper {
                 if (match.kind === MatchResultKind.FOUND) {
                     node = node[match.specialKey.indicator];
 
+                    lastSpecialKeyMatch = match;
                     index += match.matchedCount - 1;
                     continue;
                 }

--- a/src/Mappers/Generic.ts
+++ b/src/Mappers/Generic.ts
@@ -82,7 +82,7 @@ export abstract class GenericMapper {
                     return false;
                 }
 
-                match = specialKey.matchSpecial(inputs.slice(index));
+                match = specialKey.matchSpecial(inputs.slice(index), additionalArgs);
 
                 return match ? true : false;
             });
@@ -90,10 +90,6 @@ export abstract class GenericMapper {
             if (match) {
                 if (match.kind === MatchResultKind.FOUND) {
                     node = node[match.specialKey.indicator];
-
-                    Object.getOwnPropertyNames(match.additionalArgs).forEach(key => {
-                        additionalArgs[key] = match!.additionalArgs[key];
-                    });
 
                     index += match.matchedCount - 1;
                     continue;

--- a/src/Mappers/SpecialKeys/Char.ts
+++ b/src/Mappers/SpecialKeys/Char.ts
@@ -13,18 +13,22 @@ export class SpecialKeyChar implements SpecialKeyCommon {
         }
     }
 
-    matchSpecial(inputs: string[]): SpecialKeyMatchResult {
+    matchSpecial(
+        inputs: string[],
+        additionalArgs: {[key: string]: any},
+    ): SpecialKeyMatchResult | null {
         let character = inputs[0];
 
         if (character === 'space') {
             character = ' ';
         }
 
+        additionalArgs.character = character;
+
         return {
             specialKey: this,
             kind: MatchResultKind.FOUND,
             matchedCount: 1,
-            additionalArgs: {character}
         };
     }
 

--- a/src/Mappers/SpecialKeys/Char.ts
+++ b/src/Mappers/SpecialKeys/Char.ts
@@ -16,6 +16,7 @@ export class SpecialKeyChar implements SpecialKeyCommon {
     matchSpecial(
         inputs: string[],
         additionalArgs: {[key: string]: any},
+        lastSpecialKeyMatch?: SpecialKeyMatchResult,
     ): SpecialKeyMatchResult | null {
         let character = inputs[0];
 

--- a/src/Mappers/SpecialKeys/Common.ts
+++ b/src/Mappers/SpecialKeys/Common.ts
@@ -4,12 +4,14 @@ export interface SpecialKeyMatchResult {
     specialKey: SpecialKeyCommon;
     kind: MatchResultKind;
     matchedCount: number;
-    additionalArgs: {};
 }
 
 export interface SpecialKeyCommon {
     indicator: string;
 
     unmapConflicts(node: RecursiveMap, keyToMap: string): void;
-    matchSpecial(inputs: string[]): SpecialKeyMatchResult | null;
+    matchSpecial(
+        inputs: string[],
+        additionalArgs: {[key: string]: any},
+    ): SpecialKeyMatchResult | null;
 }

--- a/src/Mappers/SpecialKeys/Common.ts
+++ b/src/Mappers/SpecialKeys/Common.ts
@@ -13,5 +13,6 @@ export interface SpecialKeyCommon {
     matchSpecial(
         inputs: string[],
         additionalArgs: {[key: string]: any},
+        lastSpecialKeyMatch?: SpecialKeyMatchResult,
     ): SpecialKeyMatchResult | null;
 }

--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -1,6 +1,5 @@
 import {GenericMapper, GenericMap, RecursiveMap, MatchResultKind} from '../Generic';
 import {SpecialKeyCommon, SpecialKeyMatchResult} from './Common';
-import {SpecialKeyN} from './N';
 import {SpecialKeyChar} from './Char';
 import {Motion} from '../../Motions/Motion';
 import {MotionCharacter} from '../../Motions/Character';
@@ -23,38 +22,24 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
 
     indicator = '{motion}';
 
-    private conflictRegExp = /^[1-9]|\{N\}|\{char\}$/;
+    private conflictRegExp = /^[1-9]|\{char\}$/;
 
     private maps: MotionMap[] = [
-        { keys: 'h',         motionGenerators: [MotionCharacter.left] },
-        { keys: '{N} h',     motionGenerators: [MotionCharacter.left] },
-        { keys: 'left',      motionGenerators: [MotionCharacter.left] },
-        { keys: '{N} left',  motionGenerators: [MotionCharacter.left] },
-        { keys: 'l',         motionGenerators: [MotionCharacter.right] },
-        { keys: '{N} l',     motionGenerators: [MotionCharacter.right] },
-        { keys: 'right',     motionGenerators: [MotionCharacter.right] },
-        { keys: '{N} right', motionGenerators: [MotionCharacter.right] },
-        { keys: 'k',         motionGenerators: [MotionCharacter.up] },
-        { keys: '{N} k',     motionGenerators: [MotionCharacter.up] },
-        { keys: 'up',        motionGenerators: [MotionCharacter.up] },
-        { keys: '{N} up',    motionGenerators: [MotionCharacter.up] },
-        { keys: 'j',         motionGenerators: [MotionCharacter.down] },
-        { keys: '{N} j',     motionGenerators: [MotionCharacter.down] },
-        { keys: 'down',      motionGenerators: [MotionCharacter.down] },
-        { keys: '{N} down',  motionGenerators: [MotionCharacter.down] },
+        { keys: 'h',     motionGenerators: [MotionCharacter.left] },
+        { keys: 'left',  motionGenerators: [MotionCharacter.left] },
+        { keys: 'l',     motionGenerators: [MotionCharacter.right] },
+        { keys: 'right', motionGenerators: [MotionCharacter.right] },
+        { keys: 'k',     motionGenerators: [MotionCharacter.up] },
+        { keys: 'up',    motionGenerators: [MotionCharacter.up] },
+        { keys: 'j',     motionGenerators: [MotionCharacter.down] },
+        { keys: 'down',  motionGenerators: [MotionCharacter.down] },
 
         { keys: 'w', motionGenerators: [MotionWord.nextStart] },
-        { keys: '{N} w', motionGenerators: [MotionWord.nextStart] },
         { keys: 'W', motionGenerators: [MotionWord.nextStart], args: {useBlankSeparatedStyle: true} },
-        { keys: '{N} W', motionGenerators: [MotionWord.nextStart], args: {useBlankSeparatedStyle: true} },
         { keys: 'e', motionGenerators: [MotionWord.nextEnd] },
-        { keys: '{N} e', motionGenerators: [MotionWord.nextEnd] },
         { keys: 'E', motionGenerators: [MotionWord.nextEnd], args: {useBlankSeparatedStyle: true} },
-        { keys: '{N} E', motionGenerators: [MotionWord.nextEnd], args: {useBlankSeparatedStyle: true} },
         { keys: 'b', motionGenerators: [MotionWord.prevStart] },
-        { keys: '{N} b', motionGenerators: [MotionWord.prevStart] },
         { keys: 'B', motionGenerators: [MotionWord.prevStart], args: {useBlankSeparatedStyle: true} },
-        { keys: '{N} B', motionGenerators: [MotionWord.prevStart], args: {useBlankSeparatedStyle: true} },
 
         { keys: 'f {char}', motionGenerators: [MotionMatch.next] },
         { keys: 'F {char}', motionGenerators: [MotionMatch.prev] },
@@ -68,29 +53,21 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
         { keys: '$', motionGenerators: [MotionLine.end] },
 
         { keys: '-',     motionGenerators: [MotionCharacter.up, MotionLine.firstNonBlank] },
-        { keys: '{N} -', motionGenerators: [MotionCharacter.up, MotionLine.firstNonBlank] },
         { keys: '+',     motionGenerators: [MotionCharacter.down, MotionLine.firstNonBlank] },
-        { keys: '{N} +', motionGenerators: [MotionCharacter.down, MotionLine.firstNonBlank] },
-        { keys: '_',     motionGenerators: [MotionLine.firstNonBlank] },
-        { keys: '{N} _', motionGenerators: [
-            (args: {n: number}) => MotionCharacter.down({ n: args.n - 1 }),
+        { keys: '_', motionGenerators: [
+            (args: {n?: number}) => MotionCharacter.down({ n: (args.n === undefined ? 0 : args.n - 1) }),
             MotionLine.firstNonBlank
         ] },
 
-        { keys: 'g g',     motionGenerators: [MotionDocument.toLine, MotionLine.firstNonBlank], args: {n: 1} },
-        { keys: '{N} g g', motionGenerators: [MotionDocument.toLine, MotionLine.firstNonBlank] },
-        { keys: 'G',       motionGenerators: [MotionDocument.toLine, MotionLine.firstNonBlank], args: {n: +Infinity} },
-        { keys: '{N} G',   motionGenerators: [MotionDocument.toLine, MotionLine.firstNonBlank] },
+        { keys: 'g g', motionGenerators: [MotionDocument.toLineOrFirst, MotionLine.firstNonBlank] },
+        { keys: 'G',   motionGenerators: [MotionDocument.toLineOrLast, MotionLine.firstNonBlank] },
 
         { keys: 'space', motionGenerators: [MotionDirection.next] },
-        { keys: '{N} space', motionGenerators: [MotionDirection.next] },
         { keys: 'backspace', motionGenerators: [MotionDirection.previous] },
-        { keys: '{N} backspace', motionGenerators: [MotionDirection.previous] },
     ];
 
     constructor() {
         super([
-            new SpecialKeyN(),
             new SpecialKeyChar(),
         ]);
 

--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -1,5 +1,6 @@
 import {GenericMapper, GenericMap, RecursiveMap, MatchResultKind} from '../Generic';
 import {SpecialKeyCommon, SpecialKeyMatchResult} from './Common';
+import {SpecialKeyN} from './N';
 import {SpecialKeyChar} from './Char';
 import {Motion} from '../../Motions/Motion';
 import {MotionCharacter} from '../../Motions/Character';
@@ -98,6 +99,7 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
     matchSpecial(
         inputs: string[],
         additionalArgs: {[key: string]: any},
+        lastSpecialKeyMatch?: SpecialKeyMatchResult,
     ): SpecialKeyMatchResult | null {
         const {kind, map} = this.match(inputs);
 
@@ -106,6 +108,12 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
         }
 
         if (map) {
+            // Take N from last special key match.
+            if (lastSpecialKeyMatch && lastSpecialKeyMatch.specialKey instanceof SpecialKeyN) {
+                map.args = Object.assign(map.args, { n: additionalArgs.n });
+                delete additionalArgs.n;
+            }
+
             additionalArgs.motions = (map as MotionMap).motionGenerators.map(generator => generator(map.args));
         }
 

--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -95,14 +95,16 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
         // This class has lower priority than other keys.
     }
 
-    matchSpecial(inputs: string[]): SpecialKeyMatchResult | null {
+    matchSpecial(
+        inputs: string[],
+        additionalArgs: {[key: string]: any},
+    ): SpecialKeyMatchResult | null {
         const {kind, map} = this.match(inputs);
 
         if (kind === MatchResultKind.FAILED) {
             return null;
         }
 
-        let additionalArgs: {motions?: Motion[]} = {};
         if (map) {
             additionalArgs.motions = (map as MotionMap).motionGenerators.map(generator => generator(map.args));
         }
@@ -111,7 +113,6 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
             specialKey: this,
             kind,
             matchedCount: inputs.length,
-            additionalArgs
         };
     }
 

--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -22,7 +22,7 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
 
     indicator = '{motion}';
 
-    private conflictRegExp = /^[1-9]|\{char\}$/;
+    private conflictRegExp = /^[0]|\{char\}$/;
 
     private maps: MotionMap[] = [
         { keys: 'h',     motionGenerators: [MotionCharacter.left] },

--- a/src/Mappers/SpecialKeys/N.ts
+++ b/src/Mappers/SpecialKeys/N.ts
@@ -5,7 +5,7 @@ export class SpecialKeyN implements SpecialKeyCommon {
 
     indicator = '{N}';
 
-    private conflictRegExp = /^[1-9]|\{textObject\}|\{char\}$/;
+    private conflictRegExp = /^[1-9]|\{char\}$/;
 
     unmapConflicts(node: RecursiveMap, keyToMap: string): void {
         if (keyToMap === this.indicator) {

--- a/src/Mappers/SpecialKeys/N.ts
+++ b/src/Mappers/SpecialKeys/N.ts
@@ -22,6 +22,7 @@ export class SpecialKeyN implements SpecialKeyCommon {
     matchSpecial(
         inputs: string[],
         additionalArgs: {[key: string]: any},
+        lastSpecialKeyMatch?: SpecialKeyMatchResult,
     ): SpecialKeyMatchResult | null {
         if (! /[1-9]/.test(inputs[0])) {
             return null;

--- a/src/Mappers/SpecialKeys/N.ts
+++ b/src/Mappers/SpecialKeys/N.ts
@@ -19,7 +19,10 @@ export class SpecialKeyN implements SpecialKeyCommon {
         }
     }
 
-    matchSpecial(inputs: string[]): SpecialKeyMatchResult | null {
+    matchSpecial(
+        inputs: string[],
+        additionalArgs: {[key: string]: any},
+    ): SpecialKeyMatchResult | null {
         if (! /[1-9]/.test(inputs[0])) {
             return null;
         }
@@ -34,11 +37,12 @@ export class SpecialKeyN implements SpecialKeyCommon {
             return false;
         });
 
+        additionalArgs.n = parseInt(n.join(''), 10);
+
         return {
             specialKey: this,
             kind: MatchResultKind.FOUND,
             matchedCount: n.length,
-            additionalArgs: {n: parseInt(n.join(''), 10)}
         };
     }
 

--- a/src/Mappers/SpecialKeys/N.ts
+++ b/src/Mappers/SpecialKeys/N.ts
@@ -5,7 +5,7 @@ export class SpecialKeyN implements SpecialKeyCommon {
 
     indicator = '{N}';
 
-    private conflictRegExp = /^[1-9]|\{motion\}|\{textObject\}|\{char\}$/;
+    private conflictRegExp = /^[1-9]|\{textObject\}|\{char\}$/;
 
     unmapConflicts(node: RecursiveMap, keyToMap: string): void {
         if (keyToMap === this.indicator) {

--- a/src/Mappers/SpecialKeys/TextObject.ts
+++ b/src/Mappers/SpecialKeys/TextObject.ts
@@ -23,7 +23,7 @@ export class SpecialKeyTextObject extends GenericMapper implements SpecialKeyCom
 
     indicator = '{textObject}';
 
-    private conflictRegExp = /^[1-9]|\{N\}|\{char\}$/;
+    private conflictRegExp = /^[ai]|\{char\}$/;
 
     private mapInfos: TextObjectMapInfo[] = [
         {

--- a/src/Mappers/SpecialKeys/TextObject.ts
+++ b/src/Mappers/SpecialKeys/TextObject.ts
@@ -107,6 +107,7 @@ export class SpecialKeyTextObject extends GenericMapper implements SpecialKeyCom
     matchSpecial(
         inputs: string[],
         additionalArgs: {[key: string]: any},
+        lastSpecialKeyMatch?: SpecialKeyMatchResult,
     ): SpecialKeyMatchResult | null {
         const {kind, map} = this.match(inputs);
 

--- a/src/Mappers/SpecialKeys/TextObject.ts
+++ b/src/Mappers/SpecialKeys/TextObject.ts
@@ -104,14 +104,16 @@ export class SpecialKeyTextObject extends GenericMapper implements SpecialKeyCom
         // This class has lower priority than other keys.
     }
 
-    matchSpecial(inputs: string[]): SpecialKeyMatchResult | null {
+    matchSpecial(
+        inputs: string[],
+        additionalArgs: {[key: string]: any},
+    ): SpecialKeyMatchResult | null {
         const {kind, map} = this.match(inputs);
 
         if (kind === MatchResultKind.FAILED) {
             return null;
         }
 
-        let additionalArgs: {textObject?: TextObject} = {};
         if (map) {
             additionalArgs.textObject = (map as TextObjectMap).textObjectGenerator(map.args);
         }
@@ -120,7 +122,6 @@ export class SpecialKeyTextObject extends GenericMapper implements SpecialKeyCom
             specialKey: this,
             kind,
             matchedCount: inputs.length,
-            additionalArgs
         };
     }
 

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -166,7 +166,9 @@ export class ModeNormal extends Mode {
         { keys: 'y {N} {motion}', actions: [ActionRegister.yankByMotions] },
         { keys: 'y {textObject}', actions: [ActionRegister.yankByTextObject] },
         { keys: 'p', actions: [ActionRegister.putAfter] },
+        { keys: '{N} p', actions: [ActionRegister.putAfter] },
         { keys: 'P', actions: [ActionRegister.putBefore] },
+        { keys: '{N} P', actions: [ActionRegister.putBefore] },
 
         { keys: 'n', actions: [ActionFind.next] },
         { keys: 'N', actions: [ActionFind.prev] },

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -81,6 +81,7 @@ export class ModeNormal extends Mode {
         } },
         { keys: 'd d', actions: [ActionDelete.byLines], args: {shouldYank: true} },
         { keys: '{N} d d', actions: [ActionDelete.byLines], args: {shouldYank: true} },
+        { keys: 'd {N} d', actions: [ActionDelete.byLines], args: {shouldYank: true} },
         { keys: 'D', actions: [
             ActionDelete.byMotions,
             ActionSelection.validateSelections,

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -159,6 +159,8 @@ export class ModeNormal extends Mode {
         ] },
 
         { keys: 'y y', actions: [ActionRegister.yankLines] },
+        { keys: '{N} y y', actions: [ActionRegister.yankLines] },
+        { keys: 'y {N} y', actions: [ActionRegister.yankLines] },
         { keys: 'Y', actions: [ActionRegister.yankLines] },
         { keys: 'y {motion}', actions: [ActionRegister.yankByMotions] },
         { keys: 'y {N} {motion}', actions: [ActionRegister.yankByMotions] },

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -80,6 +80,7 @@ export class ModeNormal extends Mode {
             shouldYank: true
         } },
         { keys: 'd d', actions: [ActionDelete.byLines], args: {shouldYank: true} },
+        { keys: '{N} d d', actions: [ActionDelete.byLines], args: {shouldYank: true} },
         { keys: 'D', actions: [
             ActionDelete.byMotions,
             ActionSelection.validateSelections,

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -31,6 +31,7 @@ export class ModeNormal extends Mode {
 
     private maps: CommandMap[] = [
         { keys: '{motion}', actions: [ActionMoveCursor.byMotions], args: {noEmptyAtLineEnd: true} },
+        { keys: '{N} {motion}', actions: [ActionMoveCursor.byMotions], args: {noEmptyAtLineEnd: true} },
 
         { keys: 'ctrl+b', actions: [ActionPage.up] },
         { keys: 'ctrl+f', actions: [ActionPage.down] },
@@ -92,6 +93,12 @@ export class ModeNormal extends Mode {
         ], args: {
             shouldYank: true
         } },
+        { keys: 'd {N} {motion}', actions: [
+            ActionDelete.byMotions,
+            ActionSelection.validateSelections,
+        ], args: {
+            shouldYank: true
+        } },
         { keys: 'd {textObject}', actions: [
             ActionDelete.byTextObject,
             ActionSelection.validateSelections,
@@ -128,6 +135,13 @@ export class ModeNormal extends Mode {
             shouldYank: true,
             isChangeAction: true,
         } },
+        { keys: 'c {N} {motion}', actions: [
+            ActionDelete.byMotions,
+            ActionMode.toInsert,
+        ], args: {
+            shouldYank: true,
+            isChangeAction: true,
+        } },
         { keys: 'c {textObject}', actions: [
             ActionDelete.byTextObject,
             ActionMode.toInsert,
@@ -145,6 +159,7 @@ export class ModeNormal extends Mode {
         { keys: 'y y', actions: [ActionRegister.yankLines] },
         { keys: 'Y', actions: [ActionRegister.yankLines] },
         { keys: 'y {motion}', actions: [ActionRegister.yankByMotions] },
+        { keys: 'y {N} {motion}', actions: [ActionRegister.yankByMotions] },
         { keys: 'y {textObject}', actions: [ActionRegister.yankByTextObject] },
         { keys: 'p', actions: [ActionRegister.putAfter] },
         { keys: 'P', actions: [ActionRegister.putBefore] },
@@ -161,6 +176,7 @@ export class ModeNormal extends Mode {
         ] },
 
         { keys: '= {motion}', actions: [ActionFilter.Format.byMotions] },
+        { keys: '= {N} {motion}', actions: [ActionFilter.Format.byMotions] },
         { keys: '= =', actions: [ActionFilter.Format.byCursors] },
 
         { keys: 'u', actions: [

--- a/src/Modes/Visual.ts
+++ b/src/Modes/Visual.ts
@@ -27,6 +27,7 @@ export class ModeVisual extends Mode {
 
     private maps: CommandMap[] = [
         { keys: '{motion}', actions: [ActionMoveCursor.byMotions], args: {isVisualMode: true} },
+        { keys: '{N} {motion}', actions: [ActionMoveCursor.byMotions], args: {isVisualMode: true} },
         { keys: '{textObject}', actions: [ActionSelection.expandByTextObject]},
 
         { keys: 'ctrl+b', actions: [ActionPage.up], args: {moveType: PageMoveType.Select} },

--- a/src/Modes/VisualLine.ts
+++ b/src/Modes/VisualLine.ts
@@ -27,6 +27,7 @@ export class ModeVisualLine extends Mode {
 
     private maps: CommandMap[] = [
         { keys: '{motion}', actions: [ActionMoveCursor.byMotions], args: {isVisualLineMode: true} },
+        { keys: '{N} {motion}', actions: [ActionMoveCursor.byMotions], args: {isVisualLineMode: true} },
 
         { keys: 'ctrl+b', actions: [ActionPage.up], args: {moveType: PageMoveType.SelectLine} },
         { keys: 'ctrl+f', actions: [ActionPage.down], args: {moveType: PageMoveType.SelectLine} },

--- a/src/Motions/Document.ts
+++ b/src/Motions/Document.ts
@@ -12,6 +12,14 @@ export class MotionDocument extends Motion {
         return obj;
     }
 
+    static toLineOrFirst(args: {n?: number}): Motion {
+        return MotionDocument.toLine({n: args.n === undefined ? 1 : args.n});
+    }
+
+    static toLineOrLast(args: {n?: number}): Motion {
+        return MotionDocument.toLine({n: args.n === undefined ? +Infinity : args.n});
+    }
+
     apply(from: Position): Position {
         from = super.apply(from);
 

--- a/test/ModeNormal/d {N} d.test.ts
+++ b/test/ModeNormal/d {N} d.test.ts
@@ -1,0 +1,25 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: d {N} d', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: 'd 1 d',
+            to: '[]Bar end\nDoo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: 'd 2 d',
+            to: '[]Doo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: 'd 10 d',
+            to: '[]',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/ModeNormal/y y.test.ts
+++ b/test/ModeNormal/y y.test.ts
@@ -1,0 +1,20 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: y y', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            from: 'Fo[]o end\nBar end',
+            inputs: 'y y p',
+            to: 'Foo end\n[]Foo end\nBar end',
+        },
+        {
+            from: 'Foo end\n[]Bar end',
+            inputs: 'y y p',
+            to: 'Foo end\nBar end\n[]Bar end',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/ModeNormal/y {N} y.test.ts
+++ b/test/ModeNormal/y {N} y.test.ts
@@ -1,0 +1,25 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: y {N} y', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: 'y 1 y p',
+            to: 'Foo end\n[]Foo end\nBar end\nDoo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: 'y 2 y p',
+            to: 'Foo end\n[]Foo end\nBar end\nBar end\nDoo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: 'y 10 y p',
+            to: 'Foo end\n[]Foo end\nBar end\nDoo endBar end\nDoo end',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/ModeNormal/{N} d d.test.ts
+++ b/test/ModeNormal/{N} d d.test.ts
@@ -1,0 +1,25 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: {N} d d', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: '1 d d',
+            to: '[]Bar end\nDoo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: '2 d d',
+            to: '[]Doo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: '10 d d',
+            to: '[]',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/ModeNormal/{N} p.test.ts
+++ b/test/ModeNormal/{N} p.test.ts
@@ -1,0 +1,85 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: {N} p', () => {
+    const testCases: BlackBox.TestCase[] = [
+        // linewise
+        {
+            from: 'Fo[]o end\nBar end',
+            inputs: 'y y 1 p',
+            to: 'Foo end\n[]Foo end\nBar end',
+        },
+        {
+            from: 'Fo[]o end\nBar end',
+            inputs: 'y y 2 p',
+            to: 'Foo end\n[]Foo end\nFoo end\nBar end',
+        },
+        // single line
+        {
+            from: '[Foo] end\nBar end',
+            inputs: 'y 1 p',
+            to: 'FFo[]ooo end\nBar end',
+        },
+        {
+            from: '[Foo] end\nBar end',
+            inputs: 'y 2 p',
+            to: 'FFooFo[]ooo end\nBar end',
+        },
+        // multiple line
+        {
+            from: '[Foo end\nBar] end',
+            inputs: 'y 1 p',
+            to: 'F[]Foo end\nBaroo end\nBar end',
+        },
+        {
+            from: '[Foo end\nBar] end',
+            inputs: 'y 2 p',
+            to: 'F[]Foo end\nBarFoo end\nBaroo end\nBar end',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});
+
+suite('Normal: {N} P', () => {
+    const testCases: BlackBox.TestCase[] = [
+        // linewise
+        {
+            from: 'Fo[]o end\nBar end',
+            inputs: 'y y 1 P',
+            to: '[]Foo end\nFoo end\nBar end',
+        },
+        {
+            from: 'Fo[]o end\nBar end',
+            inputs: 'y y 2 P',
+            to: '[]Foo end\nFoo end\nFoo end\nBar end',
+        },
+        // single line
+        {
+            from: 'Foo [end]\nBar end',
+            inputs: 'y 1 P',
+            to: 'Foo en[]dend\nBar end',
+        },
+        {
+            from: 'Foo [end]\nBar end',
+            inputs: 'y 2 P',
+            to: 'Foo enden[]dend\nBar end',
+        },
+        // multiple line
+        {
+            from: 'Foo [end\nBar] end',
+            inputs: 'y 1 P',
+            to: 'Foo []end\nBarend\nBar end',
+        },
+        {
+            from: 'Foo [end\nBar] end',
+            inputs: 'y 2 P',
+            to: 'Foo []end\nBarend\nBarend\nBar end',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/ModeNormal/{N} y y.test.ts
+++ b/test/ModeNormal/{N} y y.test.ts
@@ -1,0 +1,25 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: {N} y y', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: '1 y y p',
+            to: 'Foo end\n[]Foo end\nBar end\nDoo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: '2 y y p',
+            to: 'Foo end\n[]Foo end\nBar end\nBar end\nDoo end',
+        },
+        {
+            from: 'Fo[]o end\nBar end\nDoo end',
+            inputs: '10 y y p',
+            to: 'Foo end\n[]Foo end\nBar end\nDoo endBar end\nDoo end',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});


### PR DESCRIPTION
This addresses:
- #128 
- #26
- #25
- #20 

Added support for:
- `Ndd`, `dNd`
- `Nyy`, `yNy`
- `Np`, `NP`

Other commands support for `N` will be added in separate pull requests.