### PR TITLE
Fix #176 tab switch loses cursor location

### DIFF
--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -57,14 +57,17 @@ export class Dispatcher {
                 }, 0);
             }),
             window.onDidChangeActiveTextEditor(() => {
-                if (Configuration.defaultModeID === ModeID.INSERT) {
-                    ActionMode.toInsert();
-                }
-                else {
-                    // Passing `null` to `currentMode` to force mode switch.
-                    ActionMode.switchByActiveSelections(null);
-                }
-                ActionMoveCursor.updatePreferedColumn();
+                // Ensure correct selection after changing to new TextEditor
+                setTimeout(() => {
+                    if (Configuration.defaultModeID === ModeID.INSERT) {
+                        ActionMode.toInsert();
+                    }
+                    else {
+                        // Passing `null` to `currentMode` to force mode switch.
+                        ActionMode.switchByActiveSelections(null);
+                    }
+                    ActionMoveCursor.updatePreferedColumn();
+                }, 0);
             })
         );
     }


### PR DESCRIPTION
#176 
The issue is caused by whenever you exit the Insert mode, we would perform `ActionMoveCursor.byMotion()`, but doing it immediately, the active [textEditor can't get the correct the selections](https://github.com/aioutecism/amVim-for-VSCode/blob/master/src/Actions/MoveCursor.ts#L67), only (0, 0) will be used.
This could be solved by setTimeout and I tested it works fine for me.