### PR TITLE
(chore) added clean npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     ],
     "scripts": {
         "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
+        "clean": "rimraf ./out",
+        "compile": "npm run clean && tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./node_modules/vscode/bin/test",
@@ -117,6 +118,7 @@
         "@types/node": "^8.6.0",
         "github-releases-renderer": "github:aioutecism/github-releases-renderer",
         "mocha": "^5.1.1",
+        "rimraf": "^2.6.2",
         "typescript": "^2.8.3",
         "vscode": "^1.1.14"
     }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "vscode:prepublish": "npm run compile",
         "clean": "rimraf ./out",
         "compile": "npm run clean && tsc -p ./",
-        "watch": "tsc -watch -p ./",
+        "watch": "npm run clean && tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./node_modules/vscode/bin/test",
         "sync-changelog": "node ./node_modules/github-releases-renderer/index.js run aioutecism amVim-for-VSCode CHANGELOG.template.md CHANGELOG.md -c 0"


### PR DESCRIPTION
When switching branches, tests in the `out` directory from a previous branch which don't exist the current branch will fail.

This PR deletes the `out` directory using `rimraf` before compiling.
