### PR TITLE
Find.ts us workbench.action.focusActiveEditorGroup instead of search action.focusActiveEditor

### DIFF
--- a/src/Actions/Find.ts
+++ b/src/Actions/Find.ts
@@ -8,7 +8,7 @@ export class ActionFind {
     }
 
     static executeNativeFind(): Thenable<boolean> {
-        return commands.executeCommand('search.action.focusActiveEditor')
+        return commands.executeCommand('workbench.action.focusActiveEditorGroup')
             .then(ActionSelection.shrinkToEnds);
     }
 


### PR DESCRIPTION
Seems like `action.focusActiveEditor` command has been removed with VSCode 1.25.0

I've found a `workbench.action.focusActiveEditorGroup` it seems to do the same thing and it work against newest version.