### PR TITLE
Add `zt` to put cursor at top of screen

### DIFF
--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -220,6 +220,7 @@ export class ModeNormal extends Mode {
 
         { keys: 'z .', actions: [ActionReveal.primaryCursor], args: {revealType: TextEditorRevealType.InCenter} },
         { keys: 'z z', actions: [ActionReveal.primaryCursor], args: {revealType: TextEditorRevealType.InCenter} },
+        { keys: 'z t', actions: [ActionReveal.primaryCursor], args: {revealType: TextEditorRevealType.AtTop} },
         { keys: 'z c', actions: [ActionFold.fold] },
         { keys: 'z o', actions: [ActionFold.unfold] },
         { keys: 'z M', actions: [ActionFold.foldAll] },


### PR DESCRIPTION
There's further work here to support some equivalent of Vim's
`scrolloff` (see
https://stackoverflow.com/questions/26915320/vim-zt-will-redraw-the-window-with-the-cursor-at-the-top-can-you-redraw-with)
but I was missing using `zt` and it tunrs out to be an easy addition :)

Happy to follow up with a config option like `amVim.scrollOff` and support it for `zt` if you think that's useful?