### PR TITLE
add `gd` and `gD` to go to declaration and type definition

### DIFF
--- a/src/Actions/Navigation.ts
+++ b/src/Actions/Navigation.ts
@@ -1,0 +1,13 @@
+import {commands} from 'vscode';
+
+export class ActionNavigation {
+
+    static goToDeclaration(): Thenable<undefined> {
+        return commands.executeCommand('editor.action.goToDeclaration');
+    }
+
+    static goToTypeDefinition(): Thenable<undefined> {
+        return commands.executeCommand('editor.action.goToTypeDefinition');
+    }
+
+}

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -26,6 +26,7 @@ import {ActionFold} from '../Actions/Fold';
 import {ActionCommandLine} from '../Actions/CommandLine';
 import {MotionCharacter} from '../Motions/Character';
 import {MotionLine} from '../Motions/Line';
+import { ActionNavigation } from '../Actions/Navigation';
 
 export class ModeNormal extends Mode {
 
@@ -216,6 +217,9 @@ export class ModeNormal extends Mode {
 
         { keys: '< <', actions: [ActionIndent.decrease] },
         { keys: '> >', actions: [ActionIndent.increase] },
+
+        { keys: 'g d', actions: [ActionNavigation.goToDeclaration] },
+        { keys: 'g D', actions: [ActionNavigation.goToTypeDefinition] },
 
         { keys: '/', actions: [ActionFind.focusFindWidget] },
 


### PR DESCRIPTION
This PR adds support for the `gd` and `gD` commands in a way that I think makes sense in the context of VS Code.

In vim, `gd` seems to search up through the current code block to where it thinks the current identifier (variable/function) might have been defined. With this change, amVim will have the same effect, although it will also jump into a different file if the identifier you are on is defined elsewhere. This is the same action that happens in VS Code when you Ctrl-Click.

In vim, `gD` seems to search down from line 0 to where it thinks the current identifier (variable/function) might have been defined as a global. With this change, amVim will jump to the type definition of the current identifier (even if it is in a different file). This does nothing in languages without type information, but if VS Code can figure out the type, it will take you to the definition. This is a different behavior to vim, but I think it is in the spirit of what `gD` is trying to help with.

The benefit is that you can now easily jump around the source without taking your hands off the keyboard, using `gd` and `gD` to take a look at where something is defined and what its type is, then Alt-Left to quickly take you back to where you were.
