### PR TITLE
Mark extension as UI, not workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "vscode": "^1.19.0"
     },
     "main": "./out/src/extension",
+    "extensionKind": ["ui"],
     "contributes": {
         "configuration": {
             "title": "amVim configuration",


### PR DESCRIPTION
This means that when using VSCode Remote amVim will not be installed
remotely and will run on the machine, not the remote server. This keeps
it snappier as commands don't have to be run through the server.

See https://code.visualstudio.com/api/advanced-topics/remote-extensions#common-problems