### PR TITLE
Add `gd` and `gD` to go to declaration and type definition

### DIFF
--- a/src/Actions/Navigation.ts
+++ b/src/Actions/Navigation.ts
@@ -1,0 +1,13 @@
+import {commands} from 'vscode';
+
+export class ActionNavigation {
+
+    static goToDeclaration(): Thenable<undefined> {
+        return commands.executeCommand('editor.action.goToDeclaration');
+    }
+
+    static goToTypeDefinition(): Thenable<undefined> {
+        return commands.executeCommand('editor.action.goToTypeDefinition');
+    }
+
+}

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -26,6 +26,7 @@ import {ActionFold} from '../Actions/Fold';
 import {ActionCommandLine} from '../Actions/CommandLine';
 import {MotionCharacter} from '../Motions/Character';
 import {MotionLine} from '../Motions/Line';
+import { ActionNavigation } from '../Actions/Navigation';
 
 export class ModeNormal extends Mode {
 
@@ -216,6 +217,9 @@ export class ModeNormal extends Mode {
 
         { keys: '< <', actions: [ActionIndent.decrease] },
         { keys: '> >', actions: [ActionIndent.increase] },
+
+        { keys: 'g d', actions: [ActionNavigation.goToDeclaration] },
+        { keys: 'g D', actions: [ActionNavigation.goToTypeDefinition] },
 
         { keys: '/', actions: [ActionFind.focusFindWidget] },
 


### PR DESCRIPTION
Recreating this PR.

@alisonatwork @jackfranklin I just realized this PR breaks `gg` and any potential `g` started motions.

Here is what's happening:
1. `g d` and `g D` are registered at the root: root > g > d and D
2. `g g` is registered under `{motion}`: root > {motion} > g > g
3. Normal mapping will [take priority](https://github.com/aioutecism/amVim-for-VSCode/blob/master/src/Mappers/Generic.ts#L75-L82) of special mapping such as `{motion}`, so when `g` is pressed, this branch is activated: root > g
4. The next `g` will fail to match.

Vim is treating `gd` and `gD` as motions and won't jump to other files, so this won't be a problem. In our case, we probably can't do that because we may jump to another file.

In order to make both `g d` and `g g` work, we need to rewrite some logic of [`GenericMapper.match`](https://github.com/aioutecism/amVim-for-VSCode/blob/master/src/Mappers/Generic.ts#L64) so when normal mapping failed, we go back and try special mappings. This can be a bit tricky and may have performance issue. What's your thought?