### PR TITLE
Add `gd` go to definition motion

### DIFF
--- a/src/Actions/Delete.ts
+++ b/src/Actions/Delete.ts
@@ -56,11 +56,11 @@ export class ActionDelete {
                   })
                 : Promise.resolve(true)
             )
-                .then(() => {
-                    return activeTextEditor.edit((editBuilder) => {
+                .then(() =>
+                    activeTextEditor.edit((editBuilder) => {
                         ranges.forEach((range) => editBuilder.delete(range));
-                    });
-                })
+                    }),
+                )
                 .then(() => ActionSelection.shrinkToStarts())
                 .then(() => ActionReveal.primaryCursor());
         });

--- a/src/Actions/Register.ts
+++ b/src/Actions/Register.ts
@@ -96,12 +96,12 @@ export class ActionRegister {
             }, Promise.resolve(start));
             return new Range(start, end);
         });
-        return Promise.all(promisedRanges).then((ranges) => {
-            return ActionRegister.yankRanges({
+        return Promise.all(promisedRanges).then((ranges) =>
+            ActionRegister.yankRanges({
                 ranges: ranges,
                 isLinewise: isLinewise,
-            });
-        });
+            }),
+        );
     }
 
     static async yankByTextObject(args: { textObject: TextObject }): Promise<boolean> {

--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -11,6 +11,7 @@ import { MotionMatchPair } from '../../Motions/MatchPair';
 import { MotionLine } from '../../Motions/Line';
 import { MotionParagraph } from '../../Motions/Paragraph';
 import { MotionDocument } from '../../Motions/Document';
+import { MotionNavigation } from '../../Motions/Navigation';
 
 interface MotionGenerator {
     (args?: {}): Motion;
@@ -120,6 +121,8 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
 
         { keys: 'space', motionGenerators: [MotionDirection.next] },
         { keys: 'backspace', motionGenerators: [MotionDirection.prev] },
+        { keys: 'g d', motionGenerators: [MotionNavigation.toDeclaration] },
+        { keys: 'g D', motionGenerators: [MotionNavigation.toTypeDefinition] },
     ];
 
     constructor() {

--- a/src/Motions/Direction.ts
+++ b/src/Motions/Direction.ts
@@ -33,8 +33,8 @@ export class MotionDirection extends Motion {
         });
     }
 
-    apply(from: Position, option?: any): Position {
-        from = super.apply(from);
+    async apply(from: Position, option?: any): Promise<Position> {
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/src/Motions/Document.ts
+++ b/src/Motions/Document.ts
@@ -28,8 +28,8 @@ export class MotionDocument extends Motion {
         return obj;
     }
 
-    apply(from: Position): Position {
-        from = super.apply(from);
+    async apply(from: Position): Promise<Position> {
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/src/Motions/Line.ts
+++ b/src/Motions/Line.ts
@@ -22,8 +22,8 @@ export class MotionLine extends Motion {
         return obj;
     }
 
-    apply(from: Position): Position {
-        from = super.apply(from);
+    async apply(from: Position): Promise<Position> {
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/src/Motions/Match.ts
+++ b/src/Motions/Match.ts
@@ -66,10 +66,10 @@ export class MotionMatch extends Motion {
         return obj;
     }
 
-    apply(from: Position, option: { isInclusive?: boolean } = {}): Position {
+    async apply(from: Position, option: { isInclusive?: boolean } = {}): Promise<Position> {
         option.isInclusive = option.isInclusive === undefined ? false : option.isInclusive;
 
-        from = super.apply(from);
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/src/Motions/MatchPair.ts
+++ b/src/Motions/MatchPair.ts
@@ -36,15 +36,15 @@ export class MotionMatchPair extends Motion {
         return new MotionMatchPair();
     }
 
-    apply(
+    async apply(
         from: Position,
         option: {
             isInclusive?: boolean;
         } = {},
-    ): Position {
+    ): Promise<Position> {
         option.isInclusive = option.isInclusive === undefined ? false : option.isInclusive;
 
-        from = super.apply(from);
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/src/Motions/Motion.ts
+++ b/src/Motions/Motion.ts
@@ -23,7 +23,7 @@ export abstract class Motion {
         this.characterDelta += characterDelta;
     }
 
-    apply(from: Position, option?: any): Position {
+    async apply(from: Position, option?: any): Promise<Position> {
         const activeTextEditor = window.activeTextEditor;
 
         if (!activeTextEditor) {

--- a/src/Motions/Navigation.ts
+++ b/src/Motions/Navigation.ts
@@ -1,0 +1,32 @@
+import { commands, window, Position } from 'vscode';
+import { Motion } from './Motion';
+
+export class MotionNavigation extends Motion {
+    private command: string;
+
+    static toDeclaration(): Motion {
+        const obj = new MotionNavigation({ isLinewise: true });
+        obj.command = 'editor.action.goToDeclaration';
+        return obj;
+    }
+
+    static toTypeDefinition(): Motion {
+        const obj = new MotionNavigation({ isLinewise: true });
+        obj.command = 'editor.action.goToTypeDefinition';
+        return obj;
+    }
+
+    async apply(from: Position): Promise<Position> {
+        from = await super.apply(from);
+
+        const activeTextEditor = window.activeTextEditor;
+
+        if (!activeTextEditor) {
+            return from;
+        }
+
+        await commands.executeCommand(this.command);
+
+        return activeTextEditor.selection.active;
+    }
+}

--- a/src/Motions/Paragraph.ts
+++ b/src/Motions/Paragraph.ts
@@ -33,8 +33,8 @@ export class MotionParagraph extends Motion {
         });
     }
 
-    apply(from: Position): Position {
-        from = super.apply(from);
+    async apply(from: Position): Promise<Position> {
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/src/Motions/Word.ts
+++ b/src/Motions/Word.ts
@@ -79,20 +79,20 @@ export class MotionWord extends Motion {
         return obj;
     }
 
-    apply(
+    async apply(
         from: Position,
         option: {
             isInclusive?: boolean;
             isChangeAction?: boolean;
             shouldCrossLines?: boolean;
         } = {},
-    ): Position {
+    ): Promise<Position> {
         option.isInclusive = option.isInclusive === undefined ? false : option.isInclusive;
         option.isChangeAction = option.isChangeAction === undefined ? false : option.isChangeAction;
         option.shouldCrossLines =
             option.shouldCrossLines === undefined ? true : option.shouldCrossLines;
 
-        from = super.apply(from);
+        from = await super.apply(from);
 
         const activeTextEditor = window.activeTextEditor;
 

--- a/test/Framework/BlackBox.ts
+++ b/test/Framework/BlackBox.ts
@@ -3,6 +3,7 @@ import * as TestUtil from './Util';
 import { TextEditor, TextDocument, Selection, extensions } from 'vscode';
 
 export interface TestCase {
+    language?: string;
     from: string;
     inputs: string;
     to: string;
@@ -110,7 +111,7 @@ export const run = (testCase: TestCase, before?: (textEditor: TextEditor) => voi
         const toInfo = extractInfo(testCase.to);
         const inputs = testCase.inputs.split(' ');
 
-        TestUtil.createTempDocument(fromInfo.cleanText, reusableDocument).then(
+        TestUtil.createTempDocument(fromInfo.cleanText, reusableDocument, testCase.language).then(
             async (textEditor) => {
                 reusableDocument = textEditor.document;
 
@@ -125,6 +126,10 @@ export const run = (testCase: TestCase, before?: (textEditor: TextEditor) => voi
                 for (let i = 0; i < inputs.length; i++) {
                     getCurrentMode()!.input(inputs[i]);
                     await waitForMillisecond(20 * tries);
+                }
+
+                if (testCase.language) {
+                    await waitForMillisecond(50 * tries);
                 }
 
                 try {

--- a/test/ModeNormal/g d.test.ts
+++ b/test/ModeNormal/g d.test.ts
@@ -1,0 +1,43 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: g d', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            language: 'javascript',
+            from: 'class C {\n  x = 0;\n}\nconst c = new C();\n[]c.x = 1;',
+            inputs: 'g d',
+            to: 'class C {\n  x = 0;\n}\nconst []c = new C();\nc.x = 1;',
+        },
+        {
+            language: 'javascript',
+            from: 'class C {\n  x = 0;\n}\nconst c = new C();\nc.[]x = 1;',
+            inputs: 'g d',
+            to: 'class C {\n  []x = 0;\n}\nconst c = new C();\nc.x = 1;',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});
+
+suite('Normal: g D', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            language: 'javascript',
+            from: 'class C {\n  x = 0;\n}\nconst c = new C();\n[]c.x = 1;',
+            inputs: 'g D',
+            to: 'class []C {\n  x = 0;\n}\nconst c = new C();\nc.x = 1;',
+        },
+        {
+            language: 'javascript',
+            from: 'class C {\n  x = 0;\n}\nconst c = new C();\nc.[]x = 1;',
+            inputs: 'g D',
+            to: 'class C {\n  x = 0;\n}\nconst c = new C();\nc.[]x = 1;',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -7,7 +7,7 @@ export function run(): Promise<void> {
     const mocha = new Mocha({
         ui: 'tdd',
         timeout: 2500,
-        retries: 2,
+        retries: 3,
     });
     mocha.useColors(true);
 


### PR DESCRIPTION
This is a new attempt to add the VS Code "go to definition" command as the `gd` amVim motion.

In the previous approach (#250) i implemented the command as a top-level amVim action, but this caused problems because it hijacked the matching of motions that already existed, such as `gg`. I looked at several ways to solve this, but i think the most vim-like was to respect the concept of `gd` as a motion, so that's what i have attempted here.

It required three steps:

1. **Change the `Motion.apply` function to be async (i.e. return a promise).**
This was required because in order to make motions able to execute VS Code commands, they need to be able to wait for the `Thenable<boolean>` to resolve. This problem was also encountered by @Ddedalus in #230, so adding this functionality should also help enable the `[` and `]` commands. This change does make the code on the top level a bit less pretty, however. (See `ActionDelete` in particular.)
2. **Add the new `gd` (and `gD`) commands.**
These commands execute the action inside the application of the motion, then return the resulting cursor position. This works great if you are inside the same file - i.e. `dgd` and `ygd` do exactly what you would expect. Inside a different file, they can cause strange and unexpected blocks to be deleted or yanked, but that is consistent with the behavior of actual vim, so i think it's okay.
3. **Allow `language` to be set on test cases.**
In order for the language server features to work (go to definition etc) any new text document must have a language id set to something other than `plaintext` (the default). The problem i found is that loading the language server has some lag, and the integration tests were not reliably passing. So now i sleep for a while after opening the first document marked as a particular language.

Note: this supersedes #257  