### PR TITLE
revert the vscode api requirement to 1.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "engines": {
         "node": "^8.6.0",
         "npm": "^5.6.0",
-        "vscode": "^1.45.1"
+        "vscode": "^1.32.0"
     },
     "main": "./out/src/extension",
     "extensionKind": [
@@ -261,7 +261,7 @@
         "@types/glob": "^7.1.1",
         "@types/mocha": "^5.2.7",
         "@types/node": "^8.10.61",
-        "@types/vscode": "^1.45.1",
+        "@types/vscode": "^1.32.0",
         "github-releases-renderer": "github:aioutecism/github-releases-renderer",
         "glob": "^7.1.6",
         "mocha": "^6.2.3",


### PR DESCRIPTION
Since the requirement inside `engines` block impacts which versions of VS Code can install the extension, it seems fair to set it back to an older version so people can upgrade the extension even if they didn't upgrade VS Code itself.

The number is pretty arbitrary - 1.32.0 is the same version used in Microsoft's Hello World extension (https://github.com/microsoft/vscode-extension-samples/blob/master/helloworld-test-sample/package.json), which is the structure I based the test script changes on for #259. 