### PR TITLE
feat: support remote development mode with workspace execution location

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     },
     "main": "./dist/extension",
     "extensionKind": [
-        "ui"
+        "ui",
+        "workspace"
     ],
     "contributes": {
         "configuration": {


### PR DESCRIPTION
Hi! Thanks for making this awesome extension.

Recently I found the extension doesn't work in remote development, such as [GitHub Codespaces](https://github.com/codespaces):

![image](https://user-images.githubusercontent.com/2399123/102744122-056a3780-4394-11eb-90ae-a1b5603a64f6.png)

> VSCode:
> Error while installing 'amVim' extension.
> Cannot install 'amVim' because this extension has defined that it cannot run on the remote server.

---

According to the document from VSCode, it seems like the current value (`ui`) of `extensionKind` required too much access in this case. 

> "extensionKind": ["ui"] — Indicates the extension must run as a UI extension because it requires access to local assets, devices, or capabilities. Therefore, it can only run in VS Code's local extension host and will not work in the Codespaces browser-based editor (as there is no local extension host available).
> "extensionKind": ["ui", "workspace"] — Indicates the extension prefers to run as a UI extension, but does not have any hard requirements on local assets, devices, or capabilities. When using VS Code, the extension will run in VS Code's local extension host if it exists locally, otherwise will run in VS Code's workspace extension host if it exists there. When using the Codespaces browser-based editor, it will run in the remote extension host always (as no local extension host is available). The old "ui" value (as a string) maps to this type for backwards compatibility, but is considered deprecated.

---

After changing the value of `extensionKind` to `["ui", "workspace"]`, everything just works well in my Codespace (in browser):

![image](https://user-images.githubusercontent.com/2399123/102744866-bae9ba80-4395-11eb-9725-5bbaeafd43d8.png)

---

References:
 
- https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location
- https://github.com/VSCodeVim/Vim/blob/54037e8/package.json#L33-L36