### PR TITLE
improve replace command (r) and add basic replace mode (R)

### DIFF
--- a/src/Actions/Mode.ts
+++ b/src/Actions/Mode.ts
@@ -28,6 +28,12 @@ export class ActionMode {
         return commands.executeCommand(`amVim.mode.${ModeID.INSERT}`);
     }
 
+    @StaticReflect.metadata(SymbolMetadata.Action.isChange, true)
+    @StaticReflect.metadata(SymbolMetadata.Action.shouldSkipOnRepeat, true)
+    static toReplace(): Thenable<boolean | undefined> {
+        return commands.executeCommand(`amVim.mode.${ModeID.REPLACE}`);
+    }
+
     static switchByActiveSelections(currentMode: ModeID | null): Thenable<boolean> {
         const activeTextEditor = window.activeTextEditor;
 
@@ -35,7 +41,7 @@ export class ActionMode {
             return Promise.resolve(false);
         }
 
-        if (currentMode === ModeID.INSERT) {
+        if (currentMode === ModeID.INSERT || currentMode === ModeID.REPLACE) {
             return Promise.resolve(true);
         }
 

--- a/src/Actions/Replace.ts
+++ b/src/Actions/Replace.ts
@@ -64,7 +64,7 @@ export class ActionReplace {
             .edit((editBuilder) => {
                 activeTextEditor.selections.forEach((selection) => {
                     let text = activeTextEditor.document.getText(selection);
-                    editBuilder.replace(selection, text.replace(/[^\n]/g, args.character));
+                    editBuilder.replace(selection, text.replace(/[^\r\n]/g, args.character));
                 });
             })
             .then(() => ActionReveal.primaryCursor());
@@ -90,7 +90,7 @@ export class ActionReplace {
             .edit((editBuilder) => {
                 ranges.forEach((range) => {
                     let text = activeTextEditor.document.getText(range);
-                    editBuilder.replace(range, text.replace(/[^\n]/g, args.character));
+                    editBuilder.replace(range, text.replace(/[^\r\n]/g, args.character));
                 });
             })
             .then(() => ActionReveal.primaryCursor());

--- a/src/Actions/Replace.ts
+++ b/src/Actions/Replace.ts
@@ -1,6 +1,7 @@
 import { window, Range } from 'vscode';
 import { StaticReflect } from '../LanguageExtensions/StaticReflect';
 import { SymbolMetadata } from '../Symbols/Metadata';
+import { ActionInsert } from './Insert';
 import { ActionRegister } from './Register';
 import { ActionSelection } from './Selection';
 import { ActionReveal } from './Reveal';
@@ -94,5 +95,16 @@ export class ActionReplace {
                 });
             })
             .then(() => ActionReveal.primaryCursor());
+    }
+
+    @StaticReflect.metadata(SymbolMetadata.Action.isChange, true)
+    static textAtSelections(args: {
+        text: string;
+        replaceCharCnt?: number;
+    }): Thenable<boolean | undefined> {
+        if (args.replaceCharCnt !== undefined) {
+            return ActionInsert.textAtSelections(args);
+        }
+        return ActionSelection.expandToOne().then(() => ActionInsert.textAtSelections(args));
     }
 }

--- a/src/Actions/Selection.ts
+++ b/src/Actions/Selection.ts
@@ -8,7 +8,10 @@ import { UtilRange } from '../Utils/Range';
 export class ActionSelection {
     static validateSelections(): Thenable<boolean> {
         const currentMode = getCurrentMode();
-        if (currentMode !== null && currentMode.id === ModeID.INSERT) {
+        if (
+            currentMode !== null &&
+            (currentMode.id === ModeID.INSERT || currentMode.id === ModeID.REPLACE)
+        ) {
             return Promise.resolve(true);
         }
 

--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -2,6 +2,7 @@ import { window, commands, Disposable, ExtensionContext } from 'vscode';
 import * as Keys from './Keys';
 import { Mode, ModeID } from './Modes/Mode';
 import { ModeNormal } from './Modes/Normal';
+import { ModeReplace } from './Modes/Replace';
 import { ModeVisual } from './Modes/Visual';
 import { ModeVisualLine } from './Modes/VisualLine';
 import { ModeInsert } from './Modes/Insert';
@@ -21,6 +22,7 @@ export class Dispatcher {
         [ModeID.VISUAL]: new ModeVisual(),
         [ModeID.VISUAL_LINE]: new ModeVisualLine(),
         [ModeID.INSERT]: new ModeInsert(),
+        [ModeID.REPLACE]: new ModeReplace(),
     };
 
     private disposables: Disposable[] = [];
@@ -100,7 +102,14 @@ export class Dispatcher {
         this._currentMode = this.modes[id];
         this._currentMode.enter();
 
-        commands.executeCommand('setContext', 'amVim.mode', this._currentMode.name);
+        // in order not to break existing configs, we export REPLACE as INSERT
+        commands.executeCommand(
+            'setContext',
+            'amVim.mode',
+            this._currentMode === this.modes[ModeID.REPLACE]
+                ? this.modes[ModeID.INSERT].name
+                : this._currentMode.name,
+        );
 
         // For use in repeat command
         if (lastMode) {

--- a/src/Modes/Insert.ts
+++ b/src/Modes/Insert.ts
@@ -3,6 +3,7 @@ import { Mode, ModeID } from './Mode';
 import { Configuration } from '../Configuration';
 import { MatchResultKind } from '../Mappers/Generic';
 import { CommandMap } from '../Mappers/Command';
+import { Action } from '../Actions/Action';
 import { ActionRelativeLineNumbers } from '../Actions/RelativeLineNumbers';
 import { ActionInsert } from '../Actions/Insert';
 import { ActionDelete } from '../Actions/Delete';
@@ -70,7 +71,7 @@ export class ModeInsert extends Mode {
         },
     ];
 
-    constructor() {
+    constructor(private textAtSelections: Action = ActionInsert.textAtSelections) {
         super();
 
         this.maps.forEach((map) => {
@@ -114,7 +115,7 @@ export class ModeInsert extends Mode {
 
         this.pushCommandMap({
             keys: key,
-            actions: [ActionInsert.textAtSelections],
+            actions: [this.textAtSelections],
             args: {
                 text: key,
                 replaceCharCnt: args.replaceCharCnt,

--- a/src/Modes/Mode.ts
+++ b/src/Modes/Mode.ts
@@ -9,6 +9,7 @@ export enum ModeID {
     VISUAL,
     VISUAL_LINE,
     INSERT,
+    REPLACE,
 }
 
 export abstract class Mode {

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -238,6 +238,7 @@ export class ModeNormal extends Mode {
         { keys: 'J', actions: [ActionJoinLines.onSelections] },
 
         { keys: 'r {char}', actions: [ActionReplace.charactersWithCharacter] },
+        { keys: '{N} r {char}', actions: [ActionReplace.charactersWithCharacter] },
         {
             keys: '~',
             actions: [

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -239,6 +239,8 @@ export class ModeNormal extends Mode {
 
         { keys: 'r {char}', actions: [ActionReplace.charactersWithCharacter] },
         { keys: '{N} r {char}', actions: [ActionReplace.charactersWithCharacter] },
+        { keys: 'R', actions: [ActionMode.toReplace] },
+
         {
             keys: '~',
             actions: [
@@ -393,7 +395,7 @@ export class ModeNormal extends Mode {
             return;
         }
 
-        if (lastModeID === ModeID.INSERT) {
+        if (lastModeID === ModeID.INSERT || lastModeID === ModeID.REPLACE) {
             recordedCommandMaps.forEach((map) => (map.isRepeating = true));
 
             if (this._recordedCommandMaps === undefined) {

--- a/src/Modes/Replace.ts
+++ b/src/Modes/Replace.ts
@@ -1,0 +1,12 @@
+import { ModeInsert } from './Insert';
+import { ModeID } from './Mode';
+import { ActionReplace } from '../Actions/Replace';
+
+export class ModeReplace extends ModeInsert {
+    id = ModeID.REPLACE;
+    name = 'REPLACE';
+
+    constructor() {
+        super(ActionReplace.textAtSelections);
+    }
+}

--- a/test/ModeNormal/r.test.ts
+++ b/test/ModeNormal/r.test.ts
@@ -17,6 +17,16 @@ suite('Normal: r', () => {
             inputs: 'r r',
             to: 'Fo[]r',
         },
+        {
+            from: '[]Foo',
+            inputs: '3 r r',
+            to: '[]rrr',
+        },
+        {
+            from: 'Foo []Foo',
+            inputs: '3 r r',
+            to: 'Foo []rrr',
+        },
     ];
 
     for (let i = 0; i < testCases.length; i++) {

--- a/test/ModeNormal/r.test.ts
+++ b/test/ModeNormal/r.test.ts
@@ -1,0 +1,25 @@
+import * as BlackBox from '../Framework/BlackBox';
+
+suite('Normal: r', () => {
+    const testCases: BlackBox.TestCase[] = [
+        {
+            from: '[]Foo',
+            inputs: 'r r',
+            to: '[]roo',
+        },
+        {
+            from: 'F[]oo',
+            inputs: 'r r',
+            to: 'F[]ro',
+        },
+        {
+            from: 'Fo[]o',
+            inputs: 'r r',
+            to: 'Fo[]r',
+        },
+    ];
+
+    for (let i = 0; i < testCases.length; i++) {
+        BlackBox.run(testCases[i]);
+    }
+});

--- a/test/ModeNormal/r.test.ts
+++ b/test/ModeNormal/r.test.ts
@@ -27,6 +27,17 @@ suite('Normal: r', () => {
             inputs: '3 r r',
             to: 'Foo []rrr',
         },
+        {
+            from: '[]Foo []Foo',
+            inputs: '3 r r',
+            to: '[]rrr []rrr',
+        },
+        // on vim this is an error, but replace to end of line is okay
+        {
+            from: '[]Foo\nFoo',
+            inputs: '6 r r',
+            to: '[]rrr\nFoo',
+        },
     ];
 
     for (let i = 0; i < testCases.length; i++) {


### PR DESCRIPTION
This PR has some small improvements for replace command (`r`).

1. Allow replace multiple characters, e.g. `5rt` will replace 5 characters with `t`
2. Fix bug in visual mode where replace over the newline boundary would replace also the invisible carriage return character
3. Add integration test for replace command

I also added a basic version of replace mode (`R`), to resolve #243.

The initial version is a fairly simple implementation - it is essentially a subclass of insert mode, so all behaviors are identical, except just before inserting the text it expands the selection one character forwards. This handles the situation of a user just hitting `R` and starting to type normally in overwrite/replace mode. What does not quite work is:

1. Paste inside replace mode inserts from clipboard, does not replace
2. Autocomplete inside replace mode, inserts autocompletion, does not replace
3. Repeat replace mode with `.` leaves the cursor in an unexpected place sometimes

There is also one special hack, which is that even though we created a new `REPLACE` mode, it is still exported with the context of `INSERT`. The reason why is because if users already set up some keybindings that depend on `amVim.mode != 'INSERT'` we do not want those keyboard bindings to suddenly behave incorrectly in the new `REPLACE` mode. I don't think there is a better way to do this, unless we allow user key bindings to break.