### PR TITLE
fix behavior of next match (n) by nudging the cursor

### DIFF
--- a/src/Actions/Find.ts
+++ b/src/Actions/Find.ts
@@ -9,10 +9,8 @@ export class ActionFind {
     static executeNativeFind(): Thenable<boolean> {
         return commands
             .executeCommand('workbench.action.focusActiveEditorGroup')
-            .then(ActionSelection.shrinkToEnds);
+            .then(ActionSelection.shrinkToStarts);
     }
-
-    // TODO: Implement independent find function to avoid incorrect cursor position after `next()`
 
     static byIndicator(): Thenable<boolean | undefined> {
         const activeTextEditor = window.activeTextEditor;
@@ -36,14 +34,27 @@ export class ActionFind {
             return Promise.resolve(false);
         }
 
-        return commands.executeCommand('editor.action.nextMatchFindAction').then(() => {
-            window.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
-            activeTextEditor.selection = new Selection(
-                activeTextEditor.selection.end,
-                activeTextEditor.selection.end,
-            );
-            return Promise.resolve(true);
-        });
+        // vim always searches from 1 to the right of the current cursor position
+        return commands
+            .executeCommand('cursorMove', {
+                to: 'right',
+            })
+            .then(() => {
+                const before = activeTextEditor.selection;
+
+                return commands.executeCommand('editor.action.nextMatchFindAction').then(() => {
+                    window.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
+                    if (before === activeTextEditor.selection) {
+                        // nothing got matched
+                        return commands
+                            .executeCommand('cursorMove', {
+                                to: 'left',
+                            })
+                            .then(() => Promise.resolve(true));
+                    }
+                    return ActionSelection.shrinkToStarts();
+                });
+            });
     }
 
     static prev(): Thenable<boolean> {

--- a/src/Actions/Find.ts
+++ b/src/Actions/Find.ts
@@ -66,11 +66,7 @@ export class ActionFind {
 
         return commands.executeCommand('editor.action.previousMatchFindAction').then(() => {
             window.showTextDocument(activeTextEditor.document, activeTextEditor.viewColumn);
-            activeTextEditor.selection = new Selection(
-                activeTextEditor.selection.start,
-                activeTextEditor.selection.start,
-            );
-            return Promise.resolve(true);
+            return ActionSelection.shrinkToStarts();
         });
     }
 }


### PR DESCRIPTION
When searching, Vim always puts the cursor at position 0 of the matched string, then when you hit `n` it will start searching one
character to the right for the next match. VS Code always starts searching from the current position. So we hack Vim-like behavior by nudging the cursor one to the right before searching, then if we do not find any matches, we nudge it back to the left. This causes a bit of cursor jumpiness when there are no matches, but it should resolve #261.

We can't test this easily using the integration tests, but you can manual test like this.

Given you are in normal mode, and the document has text `foo foo foo`,
When you type `/oo<RET>rrn.n.`,
Then you will get `fro fro fro`. 