### PR TITLE
Add a custom "when clause context" for "waiting for input"

### DIFF
--- a/src/Modes/Mode.ts
+++ b/src/Modes/Mode.ts
@@ -1,4 +1,4 @@
-import { window } from 'vscode';
+import { commands, window } from 'vscode';
 import { StaticReflect } from '../LanguageExtensions/StaticReflect';
 import { SymbolMetadata } from '../Symbols/Metadata';
 import { MatchResultKind } from '../Mappers/Generic';
@@ -47,6 +47,7 @@ export abstract class Mode {
 
     private clearInputs(): void {
         this.inputs = [];
+        commands.executeCommand('setContext', 'amVim.inputs', '[]');
     }
 
     private clearPendings(): void {
@@ -75,6 +76,7 @@ export abstract class Mode {
             this.execute();
         } else if (kind === MatchResultKind.WAITING) {
             this.updateStatusBar(`${this.inputs.join(' ')} and...`);
+            commands.executeCommand('setContext', 'amVim.inputs', inputs.join(','));
         }
 
         return kind;

--- a/src/Modes/Mode.ts
+++ b/src/Modes/Mode.ts
@@ -47,7 +47,7 @@ export abstract class Mode {
 
     private clearInputs(): void {
         this.inputs = [];
-        commands.executeCommand('setContext', 'amVim.inputs', '[]');
+        commands.executeCommand('setContext', 'amVim.waitingForInput', false);
     }
 
     private clearPendings(): void {
@@ -76,7 +76,7 @@ export abstract class Mode {
             this.execute();
         } else if (kind === MatchResultKind.WAITING) {
             this.updateStatusBar(`${this.inputs.join(' ')} and...`);
-            commands.executeCommand('setContext', 'amVim.inputs', inputs.join(','));
+            commands.executeCommand('setContext', 'amVim.waitingForInput', true);
         }
 
         return kind;


### PR DESCRIPTION
This PR adds a [custom when clause context](https://code.visualstudio.com/api/references/when-clause-contexts#add-a-custom-when-clause-context) to check if amVim is waiting for input. For example, `g` is an incomplete input, waiting for another keystroke, e.g. another `g` (so the complete input would be `g g`).

This allows specifying more powerful keyboard shortcuts in VS Code. For example, both #21 and #184 would be fixed (at least partially) with this PR and the following keyboard shortcuts:

```json
[
  {
    "key": "j",
    "command": "cursorMove",
    "when": "editorTextFocus && amVim.mode == 'NORMAL' && !amVim.waitingForInput",
    "args": { "to": "down", "by": "wrappedLine" }
  },
  {
    "key": "k",
    "command": "cursorMove",
    "when": "editorTextFocus && amVim.mode == 'NORMAL' && !amVim.waitingForInput",
    "args": { "to": "up", "by": "wrappedLine" }
  }
]
```

No tests though. 🥲

Some more context (pun intended): `setContext` is already used in `Dispatcher.ts` for `amVim.mode` and in `Configuration.ts` for these three:

- `amVim.configuration.shouldBindCtrlCommands`
- `amVim.configuration.shouldMimicVimSearchBehavior`
- `amVim.configuration.shouldUseVimStyleNavigationInListView`

---

**Edit (Nov 12, 2022):** Changed `amVim.inputs` from string/array (e.g. `[]` or `d,3`) to `amVim.waitingForInput` (boolean).