### PR TITLE
Wrapped line support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,6 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "stopOnEntry": false,
             "sourceMaps": true,
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
@@ -22,7 +21,6 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "stopOnEntry": false,
             "sourceMaps": true,
             "args": [
                 "--disable-extensions",

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
         "vscode:prepublish": "webpack --mode production",
         "compile": "webpack --mode development",
         "test-compile": "tsc -p ./",
-        "watch": "webpack --mode development --watch --info-verbosity verbose",
+        "watch": "webpack --mode development --watch",
         "pretest": "npm run compile && npm run test-compile",
         "test": "node ./out/test/runTest.js",
         "sync-changelog": "node ./node_modules/github-releases-renderer/index.js run aioutecism amVim-for-VSCode CHANGELOG.template.md CHANGELOG.md -c 0",

--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -12,6 +12,7 @@ import { MotionLine } from '../../Motions/Line';
 import { MotionParagraph } from '../../Motions/Paragraph';
 import { MotionDocument } from '../../Motions/Document';
 import { MotionNavigation } from '../../Motions/Navigation';
+import { MotionWrappedLine } from '../../Motions/WrappedLine';
 
 interface MotionGenerator {
     (args?: {}): Motion;
@@ -93,6 +94,11 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
         { keys: '^', motionGenerators: [MotionLine.firstNonBlank] },
         { keys: '0', motionGenerators: [MotionLine.start] },
         { keys: '$', motionGenerators: [MotionLine.end] },
+
+        { keys: 'g 0', motionGenerators: [MotionWrappedLine.start] },
+        { keys: 'g $', motionGenerators: [MotionWrappedLine.end] },
+        { keys: 'g k', motionGenerators: [MotionWrappedLine.up] },
+        { keys: 'g j', motionGenerators: [MotionWrappedLine.down] },
 
         {
             keys: '-',

--- a/src/Motions/WrappedLine.ts
+++ b/src/Motions/WrappedLine.ts
@@ -1,0 +1,101 @@
+import { commands, Position, Selection, window } from 'vscode';
+import { Motion } from './Motion';
+
+export class MotionWrappedLine extends Motion {
+    readonly cursorMove: { to: string; by?: string; value?: number };
+
+    constructor(args: {
+        isLinewise?: boolean;
+        isCharacterUpdated?: boolean;
+        cursorMove: { to: string; by?: string; value?: number };
+    }) {
+        super(args);
+        this.cursorMove = args.cursorMove;
+    }
+
+    static start(): Motion {
+        return new MotionWrappedLine({
+            cursorMove: {
+                to: 'wrappedLineStart',
+            },
+        });
+    }
+
+    static end(): Motion {
+        return new MotionWrappedLine({
+            cursorMove: {
+                to: 'wrappedLineEnd',
+            },
+        });
+    }
+
+    static up(args: { n?: number } = {}): Motion {
+        return new MotionWrappedLine({
+            isLinewise: true,
+            isCharacterUpdated: false,
+            cursorMove: {
+                to: 'up',
+                by: 'wrappedLine',
+                value: args.n === undefined ? 1 : args.n,
+            },
+        });
+    }
+
+    static down(args: { n?: number } = {}): Motion {
+        return new MotionWrappedLine({
+            isLinewise: true,
+            isCharacterUpdated: false,
+            cursorMove: {
+                to: 'down',
+                by: 'wrappedLine',
+                value: args.n === undefined ? 1 : args.n,
+            },
+        });
+    }
+
+    async apply(from: Position, option: { isInclusive?: boolean } = {}): Promise<Position> {
+        option.isInclusive = option.isInclusive === undefined ? false : option.isInclusive;
+
+        const activeTextEditor = window.activeTextEditor;
+        if (!activeTextEditor) {
+            return from;
+        }
+
+        const save = activeTextEditor.selections;
+
+        if (!from.isEqual(save[0].active)) {
+            activeTextEditor.selections = [new Selection(save[0].anchor, from)];
+        }
+        await commands.executeCommand('cursorMove', {
+            ...this.cursorMove,
+            select: !activeTextEditor.selection.isEmpty,
+        });
+        const to = activeTextEditor.selection.active;
+
+        activeTextEditor.selections = save;
+
+        // this behaves differently depending if it is a movement or selection
+        if (this.cursorMove.to === 'wrappedLineEnd' && !option.isInclusive) {
+            return to.translate(0, -1);
+        }
+
+        if (!this.isLinewise) {
+            return to;
+        }
+
+        // don't change the column on the top or bottom lines
+        if (from.line === 0 && to.line === 0 && to.character === 0) {
+            return from;
+        }
+        const lastLine = activeTextEditor.document.lineCount - 1;
+        if (
+            from.line === lastLine &&
+            to.line === lastLine &&
+            to.character === activeTextEditor.document.lineAt(lastLine).text.length
+        ) {
+            return from;
+        }
+
+        return to;
+    }
+}


### PR DESCRIPTION
This is a basic implementation of the motions `g 0`, `g $`, `g j` and `j k` to navigate around with wrapped lines. See #116.

Due to the way VS Code works, we have to jump the cursor around a little bit to plan the motion before we actually execute it, which causes some unfortunate flickering, but at least the functionality is there if you need it. I wasn't easily able to add tests for this because I'm still not sure how to set up the test VS Code instance with non-default settings for line wrap.

There are a couple of known issues:

1. Visual mode sometimes switches mysteriously between one character to the left and one character to the right of where you expect it to be, specifically when you cross over the starting point of your visual selection.
2. VS Code does not remember what column you were in when you navigate up or down from a shorter wrapped line back to a longer wrapped line. The new column will just end up being the shorter one.

This addresses #116 