### PR TITLE
add g^ and gm

### DIFF
--- a/src/Mappers/SpecialKeys/Motion.ts
+++ b/src/Mappers/SpecialKeys/Motion.ts
@@ -95,8 +95,10 @@ export class SpecialKeyMotion extends GenericMapper implements SpecialKeyCommon 
         { keys: '0', motionGenerators: [MotionLine.start] },
         { keys: '$', motionGenerators: [MotionLine.end] },
 
+        { keys: 'g ^', motionGenerators: [MotionWrappedLine.firstNonBlank] },
         { keys: 'g 0', motionGenerators: [MotionWrappedLine.start] },
         { keys: 'g $', motionGenerators: [MotionWrappedLine.end] },
+        { keys: 'g m', motionGenerators: [MotionWrappedLine.middle] },
         { keys: 'g k', motionGenerators: [MotionWrappedLine.up] },
         { keys: 'g j', motionGenerators: [MotionWrappedLine.down] },
 

--- a/src/Motions/WrappedLine.ts
+++ b/src/Motions/WrappedLine.ts
@@ -13,6 +13,14 @@ export class MotionWrappedLine extends Motion {
         this.cursorMove = args.cursorMove;
     }
 
+    static firstNonBlank(): Motion {
+        return new MotionWrappedLine({
+            cursorMove: {
+                to: 'wrappedLineFirstNonWhitespaceCharacter',
+            },
+        });
+    }
+
     static start(): Motion {
         return new MotionWrappedLine({
             cursorMove: {
@@ -25,6 +33,14 @@ export class MotionWrappedLine extends Motion {
         return new MotionWrappedLine({
             cursorMove: {
                 to: 'wrappedLineEnd',
+            },
+        });
+    }
+
+    static middle(): Motion {
+        return new MotionWrappedLine({
+            cursorMove: {
+                to: 'wrappedLineColumnCenter',
             },
         });
     }


### PR DESCRIPTION
I haven't really been able to figure out how `g^` behaves differently from `g0` in my testing, but it's harmless to add. `gm` is more useful.