### PR TITLE
Await mode changes

### DIFF
--- a/src/Actions/MoveCursor.ts
+++ b/src/Actions/MoveCursor.ts
@@ -24,22 +24,20 @@ export class ActionMoveCursor {
         }, 100);
     }
 
-    static updatePreferredColumn(): Thenable<boolean> {
+    static updatePreferredColumn(): void {
         if (ActionMoveCursor.isUpdatePreferredColumnBlocked) {
-            return Promise.resolve(false);
+            return;
         }
 
         const activeTextEditor = window.activeTextEditor;
 
         if (!activeTextEditor) {
-            return Promise.resolve(false);
+            return;
         }
 
         ActionMoveCursor.preferredColumnBySelectionIndex = activeTextEditor.selections.map(
             (selection) => UtilPosition.getColumn(activeTextEditor, selection.active),
         );
-
-        return Promise.resolve(true);
     }
 
     static async byMotions(args: {

--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -68,18 +68,18 @@ export class Dispatcher {
         this.disposables.push(
             window.onDidChangeTextEditorSelection(() => {
                 // Ensure this is executed after all pending commands.
-                setTimeout(() => {
-                    ActionMode.switchByActiveSelections(this._currentMode.id);
+                setTimeout(async () => {
+                    await ActionMode.switchByActiveSelections(this._currentMode.id);
                     ActionMoveCursor.updatePreferredColumn();
                     this._currentMode.onDidChangeTextEditorSelection();
                 }, 0);
             }),
-            window.onDidChangeActiveTextEditor(() => {
+            window.onDidChangeActiveTextEditor(async () => {
                 if (Configuration.defaultModeID === ModeID.INSERT) {
-                    ActionMode.toInsert();
+                    await ActionMode.toInsert();
                 } else {
                     // Passing `null` to `currentMode` to force mode switch.
-                    ActionMode.switchByActiveSelections(null);
+                    await ActionMode.switchByActiveSelections(null);
                 }
                 ActionMoveCursor.updatePreferredColumn();
             }),

--- a/src/Modes/Insert.ts
+++ b/src/Modes/Insert.ts
@@ -269,9 +269,9 @@ export class ModeInsert extends Mode {
         this.processRecord();
     }
 
-    protected onWillCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
+    protected onWillCommandMapMakesChanges(map: CommandMap): void {
         if (!this.isRecording) {
-            return Promise.resolve(false);
+            return;
         }
 
         if (map.keys === '\n') {
@@ -285,18 +285,16 @@ export class ModeInsert extends Mode {
                 isRepeating: true,
             });
         }
-
-        return Promise.resolve(true);
     }
 
-    protected onDidCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
+    protected onDidCommandMapMakesChanges(map: CommandMap): void {
         if (!this.isRecording) {
-            return Promise.resolve(false);
+            return;
         }
 
         if (map.keys === '\n') {
             if (!this.textEditor) {
-                return Promise.resolve(false);
+                return;
             }
 
             this.recordStartPosition = this.textEditor.selection.active;
@@ -304,8 +302,6 @@ export class ModeInsert extends Mode {
                 this.recordStartPosition.line,
             ).text;
         }
-
-        return Promise.resolve(true);
     }
 
     onDidChangeTextEditorSelection(): void {

--- a/src/Modes/Mode.ts
+++ b/src/Modes/Mode.ts
@@ -96,16 +96,12 @@ export abstract class Mode {
     /**
      * Override this to do something before command map makes changes.
      */
-    protected onWillCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
-        return Promise.resolve(true);
-    }
+    protected onWillCommandMapMakesChanges(map: CommandMap): void {}
 
     /**
      * Override this to do something after command map made changes.
      */
-    protected onDidCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
-        return Promise.resolve(true);
-    }
+    protected onDidCommandMapMakesChanges(map: CommandMap): void {}
 
     /**
      * Override this to do something after selection changes.
@@ -132,7 +128,7 @@ export abstract class Mode {
                 return;
             }
 
-            let promise: Promise<boolean | undefined> = Promise.resolve(true);
+            let promise: Promise<boolean | undefined | void> = Promise.resolve(true);
 
             const isAnyActionIsChange = map.actions.some((action) => {
                 return StaticReflect.getMetadata(SymbolMetadata.Action.isChange, action);

--- a/src/Modes/Normal.ts
+++ b/src/Modes/Normal.ts
@@ -367,9 +367,9 @@ export class ModeNormal extends Mode {
         return this._recordedCommandMaps;
     }
 
-    protected onWillCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
+    protected onWillCommandMapMakesChanges(map: CommandMap): void {
         if (map.isRepeating) {
-            return Promise.resolve(false);
+            return;
         }
 
         const actions = map.actions.filter((action) => {
@@ -386,8 +386,6 @@ export class ModeNormal extends Mode {
                 isRepeating: true,
             },
         ];
-
-        return Promise.resolve(true);
     }
 
     onDidRecordFinish(recordedCommandMaps: CommandMap[], lastModeID: ModeID): void {

--- a/src/Modes/Visual.ts
+++ b/src/Modes/Visual.ts
@@ -219,7 +219,7 @@ export class ModeVisual extends Mode {
         return this._recordedCommandMaps;
     }
 
-    protected onWillCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
+    protected onWillCommandMapMakesChanges(map: CommandMap): void {
         const actions = map.actions.filter((action) => {
             return (
                 StaticReflect.getMetadata(SymbolMetadata.Action.shouldSkipOnRepeat, action) !== true
@@ -243,7 +243,5 @@ export class ModeVisual extends Mode {
                 isRepeating: true,
             },
         ];
-
-        return Promise.resolve(true);
     }
 }

--- a/src/Modes/VisualLine.ts
+++ b/src/Modes/VisualLine.ts
@@ -216,7 +216,7 @@ export class ModeVisualLine extends Mode {
         return this._recordedCommandMaps;
     }
 
-    protected onWillCommandMapMakesChanges(map: CommandMap): Promise<boolean> {
+    protected onWillCommandMapMakesChanges(map: CommandMap): void {
         const actions = map.actions.filter((action) => {
             return (
                 StaticReflect.getMetadata(SymbolMetadata.Action.shouldSkipOnRepeat, action) !== true
@@ -240,7 +240,5 @@ export class ModeVisualLine extends Mode {
                 isRepeating: true,
             },
         ];
-
-        return Promise.resolve(true);
     }
 }


### PR DESCRIPTION
This is small clean-up pull request which removes some functions that were unnecessarily declared to return promise/thenable and also adds a couple of await when we respond to selection or tab change events from the VS Code window. It's possible that this will solve #308, but since I can't reproduce it, I can't be certain.

There is a more ambitious change that would involve making the core `execute` function of each mode async and awaiting it in the input handler, but I suspect that might make the extension feel a bit laggy, so I'd rather not do that unless we're sure it's going to make a difference.