### PR TITLE
replace xvfb-action with xvfb-run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
         run: npm ci
       - name: Run lint
         run: npm run prettier-check
-      - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: npm test
+      - name: Run tests (Linux)
+        run: xvfb-run -a npm test
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Run tests (Windows/Mac)
+        run: npm test
+        if: ${{ matrix.os != 'ubuntu-latest' }}


### PR DESCRIPTION
The [GabrielBB/xvfb-action](https://github.com/GabrielBB/xvfb-action) that we use for testing is using the deprecated Node 12 base image and appears to be unmaintained. Since the `ubuntu-latest` image now includes `xvfb-run`, we can replace this image with a conditional step to use `xvfb-run` on Linux and just build straight on Windows/Mac.