### PR TITLE
Skip Up/Down keys if suggest widget is visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,12 +103,12 @@
             {
                 "command": "amVim.up",
                 "key": "up",
-                "when": "editorTextFocus && amVim.mode != 'INSERT'"
+                "when": "editorTextFocus && amVim.mode != 'INSERT' && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
             },
             {
                 "command": "amVim.down",
                 "key": "down",
-                "when": "editorTextFocus && amVim.mode != 'INSERT'"
+                "when": "editorTextFocus && amVim.mode != 'INSERT' && !suggestWidgetMultipleSuggestions && !suggestWidgetVisible"
             },
             {
                 "command": "amVim.escape",


### PR DESCRIPTION
Problem:
down/up keys don't work as expected if suggest is open