### PR TITLE
Fix 1.75 flakiness

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
     files: 'out/test/**/*.test.js',
-    version: '1.74.0',
+    version: '1.75.0',
     mocha: {
         ui: 'tdd',
         timeout: 2500,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "devDependencies": {
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^18.x",
-                "@types/vscode": "^1.74.0",
+                "@types/vscode": "^1.75.0",
                 "@typescript-eslint/eslint-plugin": "^7.0.2",
                 "@typescript-eslint/parser": "^7.0.2",
                 "@vscode/test-cli": "^0.0.6",
@@ -27,7 +27,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.74.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "author": "aioutecism",
     "license": "ISC",
     "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.75.0"
     },
     "main": "./dist/extension.js",
     "extensionKind": [
@@ -266,7 +266,7 @@
     "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^18.x",
-        "@types/vscode": "^1.74.0",
+        "@types/vscode": "^1.75.0",
         "@typescript-eslint/eslint-plugin": "^7.0.2",
         "@typescript-eslint/parser": "^7.0.2",
         "@vscode/test-cli": "^0.0.6",

--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -72,7 +72,7 @@ export class Dispatcher {
                     await ActionMode.switchByActiveSelections(this._currentMode.id);
                     ActionMoveCursor.updatePreferredColumn();
                     this._currentMode.onDidChangeTextEditorSelection();
-                }, 0);
+                }, 2);
             }),
             window.onDidChangeActiveTextEditor(async () => {
                 if (Configuration.defaultModeID === ModeID.INSERT) {


### PR DESCRIPTION
Bump vscode engine to 1.75.0 and attempt to address the test flakiness and the "cursor in the wrong position" bug reported in #308 and #317.